### PR TITLE
Single connection written to openvpn configuration

### DIFF
--- a/cmd/gluetun/main.go
+++ b/cmd/gluetun/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -328,9 +329,9 @@ func collectStreamLines(ctx context.Context, streamMerger command.StreamMerger, 
 			logger.Error(line)
 		}
 		switch {
-		case line == "openvpn: Initialization Sequence Completed":
+		case strings.Contains(line, "Initialization Sequence Completed"):
 			signalTunnelReady()
-		case line == "openvpn: TLS Error: TLS key negotiation failed to occur within 60 seconds (check your network connectivity)":
+		case strings.Contains(line, "TLS Error: TLS key negotiation failed to occur within 60 seconds (check your network connectivity)"):
 			logger.Warn("This means that either...")
 			logger.Warn("1. The VPN server IP address you are trying to connect to is no longer valid, see https://github.com/qdm12/gluetun/wiki/Update-servers-information")
 			logger.Warn("2. The VPN server crashed, try changing region")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -70,13 +70,13 @@ func OpenvpnConfig() error {
 	if err != nil {
 		return err
 	}
-	providerConf := provider.New(allSettings.OpenVPN.Provider.Name, allServers)
-	connections, err := providerConf.GetOpenVPNConnections(allSettings.OpenVPN.Provider.ServerSelection)
+	providerConf := provider.New(allSettings.OpenVPN.Provider.Name, allServers, time.Now)
+	connection, err := providerConf.GetOpenVPNConnection(allSettings.OpenVPN.Provider.ServerSelection)
 	if err != nil {
 		return err
 	}
 	lines := providerConf.BuildConf(
-		connections,
+		connection,
 		allSettings.OpenVPN.Verbosity,
 		allSettings.System.UID,
 		allSettings.System.GID,

--- a/internal/firewall/enable.go
+++ b/internal/firewall/enable.go
@@ -85,8 +85,8 @@ func (c *configurator) enable(ctx context.Context) (err error) { //nolint:gocogn
 	if err = c.acceptEstablishedRelatedTraffic(ctx, remove); err != nil {
 		return fmt.Errorf("cannot enable firewall: %w", err)
 	}
-	for _, conn := range c.vpnConnections {
-		if err = c.acceptOutputTrafficToVPN(ctx, c.defaultInterface, conn, remove); err != nil {
+	if c.vpnConnection.IP != nil {
+		if err = c.acceptOutputTrafficToVPN(ctx, c.defaultInterface, c.vpnConnection, remove); err != nil {
 			return fmt.Errorf("cannot enable firewall: %w", err)
 		}
 	}

--- a/internal/firewall/firewall.go
+++ b/internal/firewall/firewall.go
@@ -16,7 +16,7 @@ import (
 type Configurator interface {
 	Version(ctx context.Context) (string, error)
 	SetEnabled(ctx context.Context, enabled bool) (err error)
-	SetVPNConnections(ctx context.Context, connections []models.OpenVPNConnection) (err error)
+	SetVPNConnection(ctx context.Context, connection models.OpenVPNConnection) (err error)
 	SetAllowedSubnets(ctx context.Context, subnets []net.IPNet) (err error)
 	SetAllowedPort(ctx context.Context, port uint16, intf string) (err error)
 	RemoveAllowedPort(ctx context.Context, port uint16) (err error)
@@ -39,7 +39,7 @@ type configurator struct { //nolint:maligned
 
 	// State
 	enabled           bool
-	vpnConnections    []models.OpenVPNConnection
+	vpnConnection     models.OpenVPNConnection
 	allowedSubnets    []net.IPNet
 	allowedInputPorts map[uint16]string // port to interface mapping
 	stateMutex        sync.Mutex

--- a/internal/firewall/vpn.go
+++ b/internal/firewall/vpn.go
@@ -7,95 +7,33 @@ import (
 	"github.com/qdm12/gluetun/internal/models"
 )
 
-func (c *configurator) SetVPNConnections(ctx context.Context, connections []models.OpenVPNConnection) (err error) {
+func (c *configurator) SetVPNConnection(ctx context.Context, connection models.OpenVPNConnection) (err error) {
 	c.stateMutex.Lock()
 	defer c.stateMutex.Unlock()
 
 	if !c.enabled {
-		c.logger.Info("firewall disabled, only updating VPN connections internal list")
-		c.vpnConnections = make([]models.OpenVPNConnection, len(connections))
-		copy(c.vpnConnections, connections)
+		c.logger.Info("firewall disabled, only updating internal VPN connection")
+		c.vpnConnection = connection
 		return nil
 	}
 
-	c.logger.Info("setting VPN connections through firewall...")
+	c.logger.Info("setting VPN connection through firewall...")
 
-	connectionsToAdd := findConnectionsToAdd(c.vpnConnections, connections)
-	connectionsToRemove := findConnectionsToRemove(c.vpnConnections, connections)
-	if len(connectionsToAdd) == 0 && len(connectionsToRemove) == 0 {
+	if c.vpnConnection.Equal(connection) {
 		return nil
 	}
 
-	c.removeConnections(ctx, connectionsToRemove, c.defaultInterface)
-	if err := c.addConnections(ctx, connectionsToAdd, c.defaultInterface); err != nil {
-		return fmt.Errorf("cannot set VPN connections through firewall: %w", err)
-	}
-
-	return nil
-}
-
-func removeConnectionFromConnections(connections []models.OpenVPNConnection, connection models.OpenVPNConnection) []models.OpenVPNConnection {
-	L := len(connections)
-	for i := range connections {
-		if connection.Equal(connections[i]) {
-			connections[i] = connections[L-1]
-			connections = connections[:L-1]
-			break
-		}
-	}
-	return connections
-}
-
-func findConnectionsToAdd(oldConnections, newConnections []models.OpenVPNConnection) (connectionsToAdd []models.OpenVPNConnection) {
-	for _, newConnection := range newConnections {
-		found := false
-		for _, oldConnection := range oldConnections {
-			if oldConnection.Equal(newConnection) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			connectionsToAdd = append(connectionsToAdd, newConnection)
-		}
-	}
-	return connectionsToAdd
-}
-
-func findConnectionsToRemove(oldConnections, newConnections []models.OpenVPNConnection) (connectionsToRemove []models.OpenVPNConnection) {
-	for _, oldConnection := range oldConnections {
-		found := false
-		for _, newConnection := range newConnections {
-			if oldConnection.Equal(newConnection) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			connectionsToRemove = append(connectionsToRemove, oldConnection)
-		}
-	}
-	return connectionsToRemove
-}
-
-func (c *configurator) removeConnections(ctx context.Context, connections []models.OpenVPNConnection, defaultInterface string) {
-	for _, conn := range connections {
-		const remove = true
-		if err := c.acceptOutputTrafficToVPN(ctx, defaultInterface, conn, remove); err != nil {
+	remove := true
+	if c.vpnConnection.IP != nil {
+		if err := c.acceptOutputTrafficToVPN(ctx, c.defaultInterface, c.vpnConnection, remove); err != nil {
 			c.logger.Error("cannot remove outdated VPN connection through firewall: %s", err)
-			continue
 		}
-		c.vpnConnections = removeConnectionFromConnections(c.vpnConnections, conn)
 	}
-}
-
-func (c *configurator) addConnections(ctx context.Context, connections []models.OpenVPNConnection, defaultInterface string) error {
-	const remove = false
-	for _, conn := range connections {
-		if err := c.acceptOutputTrafficToVPN(ctx, defaultInterface, conn, remove); err != nil {
-			return err
-		}
-		c.vpnConnections = append(c.vpnConnections, conn)
+	c.vpnConnection = models.OpenVPNConnection{}
+	remove = false
+	if err := c.acceptOutputTrafficToVPN(ctx, c.defaultInterface, connection, remove); err != nil {
+		return fmt.Errorf("cannot set VPN connection through firewall: %w", err)
 	}
+	c.vpnConnection = connection
 	return nil
 }

--- a/internal/openvpn/loop.go
+++ b/internal/openvpn/loop.go
@@ -113,16 +113,16 @@ func (l *looper) Run(ctx context.Context, wg *sync.WaitGroup) {
 	for ctx.Err() == nil {
 		settings := l.GetSettings()
 		l.allServersMutex.RLock()
-		providerConf := provider.New(l.provider, l.allServers)
+		providerConf := provider.New(l.provider, l.allServers, time.Now)
 		l.allServersMutex.RUnlock()
-		connections, err := providerConf.GetOpenVPNConnections(settings.Provider.ServerSelection)
+		connection, err := providerConf.GetOpenVPNConnection(settings.Provider.ServerSelection)
 		if err != nil {
 			l.logger.Error(err)
 			l.cancel()
 			return
 		}
 		lines := providerConf.BuildConf(
-			connections,
+			connection,
 			settings.Verbosity,
 			l.uid,
 			l.gid,
@@ -143,7 +143,7 @@ func (l *looper) Run(ctx context.Context, wg *sync.WaitGroup) {
 			return
 		}
 
-		if err := l.fw.SetVPNConnections(ctx, connections); err != nil {
+		if err := l.fw.SetVPNConnection(ctx, connection); err != nil {
 			l.logger.Error(err)
 			l.cancel()
 			return

--- a/internal/provider/pia.go
+++ b/internal/provider/pia.go
@@ -8,7 +8,7 @@ import (
 	"github.com/qdm12/gluetun/internal/models"
 )
 
-func buildPIAConf(connections []models.OpenVPNConnection, verbosity int, root bool, cipher, auth string, extras models.ExtraConfigOptions) (lines []string) {
+func buildPIAConf(connection models.OpenVPNConnection, verbosity int, root bool, cipher, auth string, extras models.ExtraConfigOptions) (lines []string) {
 	var X509CRL, certificate string
 	if extras.EncryptionPreset == constants.PIAEncryptionPresetNormal {
 		if len(cipher) == 0 {
@@ -52,7 +52,8 @@ func buildPIAConf(connections []models.OpenVPNConnection, verbosity int, root bo
 		// Modified variables
 		fmt.Sprintf("verb %d", verbosity),
 		fmt.Sprintf("auth-user-pass %s", constants.OpenVPNAuthConf),
-		fmt.Sprintf("proto %s", connections[0].Protocol),
+		fmt.Sprintf("proto %s", connection.Protocol),
+		fmt.Sprintf("remote %s %d", connection.IP, connection.Port),
 		fmt.Sprintf("cipher %s", cipher),
 		fmt.Sprintf("auth %s", auth),
 	}
@@ -61,9 +62,6 @@ func buildPIAConf(connections []models.OpenVPNConnection, verbosity int, root bo
 	}
 	if !root {
 		lines = append(lines, "user nonrootuser")
-	}
-	for _, connection := range connections {
-		lines = append(lines, fmt.Sprintf("remote %s %d", connection.IP, connection.Port))
 	}
 	lines = append(lines, []string{
 		"<crl-verify>",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -14,33 +14,33 @@ import (
 
 // Provider contains methods to read and modify the openvpn configuration to connect as a client
 type Provider interface {
-	GetOpenVPNConnections(selection models.ServerSelection) (connections []models.OpenVPNConnection, err error)
-	BuildConf(connections []models.OpenVPNConnection, verbosity, uid, gid int, root bool, cipher, auth string, extras models.ExtraConfigOptions) (lines []string)
+	GetOpenVPNConnection(selection models.ServerSelection) (connection models.OpenVPNConnection, err error)
+	BuildConf(connection models.OpenVPNConnection, verbosity, uid, gid int, root bool, cipher, auth string, extras models.ExtraConfigOptions) (lines []string)
 	PortForward(ctx context.Context, client *http.Client,
 		fileManager files.FileManager, pfLogger logging.Logger, gateway net.IP, fw firewall.Configurator,
 		syncState func(port uint16) (pfFilepath models.Filepath))
 }
 
-func New(provider models.VPNProvider, allServers models.AllServers) Provider {
+func New(provider models.VPNProvider, allServers models.AllServers, timeNow timeNowFunc) Provider {
 	switch provider {
 	case constants.PrivateInternetAccess:
-		return newPrivateInternetAccessV4(allServers.Pia.Servers)
+		return newPrivateInternetAccessV4(allServers.Pia.Servers, timeNow)
 	case constants.PrivateInternetAccessOld:
-		return newPrivateInternetAccessV3(allServers.PiaOld.Servers)
+		return newPrivateInternetAccessV3(allServers.PiaOld.Servers, timeNow)
 	case constants.Mullvad:
-		return newMullvad(allServers.Mullvad.Servers)
+		return newMullvad(allServers.Mullvad.Servers, timeNow)
 	case constants.Windscribe:
-		return newWindscribe(allServers.Windscribe.Servers)
+		return newWindscribe(allServers.Windscribe.Servers, timeNow)
 	case constants.Surfshark:
-		return newSurfshark(allServers.Surfshark.Servers)
+		return newSurfshark(allServers.Surfshark.Servers, timeNow)
 	case constants.Cyberghost:
-		return newCyberghost(allServers.Cyberghost.Servers)
+		return newCyberghost(allServers.Cyberghost.Servers, timeNow)
 	case constants.Vyprvpn:
-		return newVyprvpn(allServers.Vyprvpn.Servers)
+		return newVyprvpn(allServers.Vyprvpn.Servers, timeNow)
 	case constants.Nordvpn:
-		return newNordvpn(allServers.Nordvpn.Servers)
+		return newNordvpn(allServers.Nordvpn.Servers, timeNow)
 	case constants.Purevpn:
-		return newPurevpn(allServers.Purevpn.Servers)
+		return newPurevpn(allServers.Purevpn.Servers, timeNow)
 	default:
 		return nil // should never occur
 	}

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -2,10 +2,14 @@ package provider
 
 import (
 	"context"
+	"math/rand"
 	"time"
 
+	"github.com/qdm12/gluetun/internal/models"
 	"github.com/qdm12/golibs/logging"
 )
+
+type timeNowFunc func() time.Time
 
 func tryUntilSuccessful(ctx context.Context, logger logging.Logger, fn func() error) {
 	const retryPeriod = 10 * time.Second
@@ -26,4 +30,8 @@ func tryUntilSuccessful(ctx context.Context, logger logging.Logger, fn func() er
 			return
 		}
 	}
+}
+
+func pickRandomConnection(connections []models.OpenVPNConnection, source rand.Source) models.OpenVPNConnection {
+	return connections[rand.New(source).Intn(len(connections))] //nolint:gosec
 }


### PR DESCRIPTION
- From now only a single OpenVPN connection is written to the OpenVPN configuration file
- If multiple connections are matched given the user parameters (i.e. city, region), it is picked at pseudo random using the current time as the pseudo random seed.
- Not relying on Openvpn picking a random remote address, may refer to #229 
- Program is aware of which connection is to be used, in order to use its matching CN for port forwarding TLS verification with PIA v4 servers, see #236 
- Simplified firewall mechanisms