### PR TITLE
PIA port forwarding final fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,4 +113,6 @@ RUN apk add -q --progress --no-cache --update openvpn ca-certificates iptables i
     deluser tinyproxy && \
     deluser unbound && \
     mkdir /gluetun
+# TODO remove once SAN is added to PIA servers certificates, see https://github.com/pia-foss/manual-connections/issues/10
+ENV GODEBUG=x509ignoreCN=0
 COPY --from=builder /tmp/gobuild/entrypoint /entrypoint

--- a/README.md
+++ b/README.md
@@ -352,10 +352,10 @@ There are various ways to achieve this, depending on your use case.
 
 ## Private Internet Access port forwarding
 
-Note that [not all regions support port forwarding](https://www.privateinternetaccess.com/helpdesk/kb/articles/how-do-i-enable-port-forwarding-on-my-vpn).
-
-When `PORT_FORWARDING=on`, a port will be forwarded on the VPN server side and written to the file specified by `PORT_FORWARDING_STATUS_FILE=/forwarded_port`.
+When `PORT_FORWARDING=on`, a port will be forwarded on the VPN server side and written to the file specified by `PORT_FORWARDING_STATUS_FILE=/tmp/gluetun/forwarded_port`.
 It can be useful to mount this file as a volume to read it from other containers, for example to configure a torrenting client.
+
+For `VPNSP=private internet access` (default), you will keep the same forwarded port for 60 days as long as you bind mount the `/gluetun` directory.
 
 You can also use the HTTP control server (see below) to get the port forwarded.
 

--- a/internal/provider/piav4.go
+++ b/internal/provider/piav4.go
@@ -126,7 +126,7 @@ func (p *piaV4) PortForward(ctx context.Context, client *http.Client,
 	if p.activeProtocol == constants.TCP {
 		commonName = p.activeServer.OpenvpnTCP.CN
 	}
-	client, err := newPIAv4HTTPClient(commonName)
+	client, err := newPIAv4HTTPClient(commonName, gateway)
 	if err != nil {
 		pfLogger.Error("aborting because: %s", err)
 		return
@@ -249,7 +249,7 @@ func filterPIAServers(servers []models.PIAServer, region string) (filtered []mod
 	return nil
 }
 
-func newPIAv4HTTPClient(commonName string) (client *http.Client, err error) {
+func newPIAv4HTTPClient(commonName string, gateway net.IP) (client *http.Client, err error) {
 	certificateBytes, err := base64.StdEncoding.DecodeString(constants.PIACertificateStrong)
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode PIA root certificate: %w", err)
@@ -261,12 +261,14 @@ func newPIAv4HTTPClient(commonName string) (client *http.Client, err error) {
 	certificate.Subject.CommonName = commonName
 	certificate.Issuer.CommonName = commonName
 	certificate.DNSNames = []string{commonName}
-	certificate.IPAddresses = []net.IP{{10, 0, 0, 1}}
+	certificate.IPAddresses = []net.IP{{10, 0, 0, 1}, gateway}
 	rootCAs := x509.NewCertPool()
 	rootCAs.AddCert(certificate)
 	TLSClientConfig := &tls.Config{
 		RootCAs:    rootCAs,
 		MinVersion: tls.VersionTLS12,
+		// TODO disable once SAN is added to PIA servers certificates, see https://github.com/pia-foss/manual-connections/issues/10
+		InsecureSkipVerify: true, //nolint:gosec
 	}
 	transport := http.Transport{
 		TLSClientConfig: TLSClientConfig,

--- a/internal/provider/piav4.go
+++ b/internal/provider/piav4.go
@@ -126,7 +126,7 @@ func (p *piaV4) PortForward(ctx context.Context, client *http.Client,
 	if p.activeProtocol == constants.TCP {
 		commonName = p.activeServer.OpenvpnTCP.CN
 	}
-	client, err := newPIAv4HTTPClient(commonName, gateway)
+	client, err := newPIAv4HTTPClient(commonName)
 	if err != nil {
 		pfLogger.Error("aborting because: %s", err)
 		return
@@ -249,7 +249,7 @@ func filterPIAServers(servers []models.PIAServer, region string) (filtered []mod
 	return nil
 }
 
-func newPIAv4HTTPClient(commonName string, gateway net.IP) (client *http.Client, err error) {
+func newPIAv4HTTPClient(serverName string) (client *http.Client, err error) {
 	certificateBytes, err := base64.StdEncoding.DecodeString(constants.PIACertificateStrong)
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode PIA root certificate: %w", err)
@@ -258,17 +258,12 @@ func newPIAv4HTTPClient(commonName string, gateway net.IP) (client *http.Client,
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse PIA root certificate: %w", err)
 	}
-	certificate.Subject.CommonName = commonName
-	certificate.Issuer.CommonName = commonName
-	certificate.DNSNames = []string{commonName}
-	certificate.IPAddresses = []net.IP{{10, 0, 0, 1}, gateway}
 	rootCAs := x509.NewCertPool()
 	rootCAs.AddCert(certificate)
 	TLSClientConfig := &tls.Config{
 		RootCAs:    rootCAs,
 		MinVersion: tls.VersionTLS12,
-		// TODO disable once SAN is added to PIA servers certificates, see https://github.com/pia-foss/manual-connections/issues/10
-		InsecureSkipVerify: true, //nolint:gosec
+		ServerName: serverName,
 	}
 	transport := http.Transport{
 		TLSClientConfig: TLSClientConfig,


### PR DESCRIPTION
- Returns an error if the server does not support port forwarding
- TLS verification using the server common name obtained through the API
- Updated readme
- Fixes #236 