### PR TITLE
Return the response of a redirect, do not follow.

### DIFF
--- a/internal/httpproxy/handler.go
+++ b/internal/httpproxy/handler.go
@@ -13,9 +13,11 @@ func newHandler(ctx context.Context, wg *sync.WaitGroup, logger logging.Logger,
 	stealth, verbose bool, username, password string) http.Handler {
 	const httpTimeout = 24 * time.Hour
 	return &handler{
-		ctx:      ctx,
-		wg:       wg,
-		client:   &http.Client{Timeout: httpTimeout},
+		ctx: ctx,
+		wg:  wg,
+		client: &http.Client{
+			Timeout:       httpTimeout,
+			CheckRedirect: returnRedirect},
 		logger:   logger,
 		verbose:  verbose,
 		stealth:  stealth,
@@ -61,4 +63,9 @@ var hopHeaders = [...]string{ //nolint:gochecknoglobals
 	"Trailers",
 	"Transfer-Encoding",
 	"Upgrade",
+}
+
+// Do not follow redirect, but directly return the redirect response.
+func returnRedirect(req *http.Request, via []*http.Request) error {
+	return http.ErrUseLastResponse
 }


### PR DESCRIPTION
Thanks for your work on this nice project.
When using the http proxy, it looked like the http redirect was handled by the proxy instead of the browser.
This PR tries to fix it.

### Problem:
When browsing to a **http** website the redirect is followed by the http proxy (Go) and the body of the **https** page is returned instead of the redirect (Statuscode 301).

Example of current situation:
```
curl -vvv -x proxy:8118 http://google.com
> GET http://google.com/ HTTP/1.1
....
< HTTP/1.1 200 OK
...
<!doctype html><html itemscope="" itemtype="http://schema.org/WebPage" lang="en-GB"><head>...<title>Google</title>...
````

### Solution
The default behaviour of the Golang http.Client is following redirects. By configuring a redirect function that always returns a
`ErrUseLastResponse`, the redirect will be returned to the client. (Documentation [http.Client](https://golang.org/pkg/net/http/#Client))

After adding the redirect function, the same curl statement returns:

```
...
> GET http://google.com/ HTTP/1.1
....
< HTTP/1.1 301 Moved Permanently
< Location: http://www.google.com/
...
<
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com/">here</A>.
</BODY></HTML>
```
