### PR TITLE
Uplift the 'localSubnet' concept to cover all local ethernet interfaces

### DIFF
--- a/cmd/gluetun/main.go
+++ b/cmd/gluetun/main.go
@@ -191,7 +191,7 @@ func _main(ctx context.Context, buildInfo models.BuildInformation,
 		return err
 	}
 
-	localSubnet, err := routingConf.LocalSubnet()
+	localSubnets, err := routingConf.LocalSubnets()
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func _main(ctx context.Context, buildInfo models.BuildInformation,
 		return err
 	}
 
-	firewallConf.SetNetworkInformation(defaultInterface, defaultGateway, localSubnet, defaultIP)
+	firewallConf.SetNetworkInformation(defaultInterface, defaultGateway, localSubnets, defaultIP)
 
 	if err := routingConf.Setup(); err != nil {
 		return err

--- a/cmd/gluetun/main.go
+++ b/cmd/gluetun/main.go
@@ -191,7 +191,7 @@ func _main(ctx context.Context, buildInfo models.BuildInformation,
 		return err
 	}
 
-	localSubnets, err := routingConf.LocalSubnets()
+	localNetworks, err := routingConf.LocalNetworks()
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func _main(ctx context.Context, buildInfo models.BuildInformation,
 		return err
 	}
 
-	firewallConf.SetNetworkInformation(defaultInterface, defaultGateway, localSubnets, defaultIP)
+	firewallConf.SetNetworkInformation(defaultInterface, defaultGateway, localNetworks, defaultIP)
 
 	if err := routingConf.Setup(); err != nil {
 		return err

--- a/internal/firewall/enable.go
+++ b/internal/firewall/enable.go
@@ -94,8 +94,8 @@ func (c *configurator) enable(ctx context.Context) (err error) {
 		return fmt.Errorf("cannot enable firewall: %w", err)
 	}
 
-	for _, subnet := range c.localSubnets {
-		if err := c.acceptOutputFromIPToSubnet(ctx, c.defaultInterface, c.localIP, subnet, remove); err != nil {
+	for _, network := range c.localNetworks {
+		if err := c.acceptOutputFromIPToSubnet(ctx, network.InterfaceName, network.IP, network.Subnet, remove); err != nil {
 			return fmt.Errorf("cannot enable firewall: %w", err)
 		}
 	}
@@ -108,8 +108,8 @@ func (c *configurator) enable(ctx context.Context) (err error) {
 
 	// Allows packets from any IP address to go through eth0 / local network
 	// to reach Gluetun.
-	for _, subnet := range c.localSubnets {
-		if err := c.acceptInputToSubnet(ctx, c.defaultInterface, subnet, remove); err != nil {
+	for _, network := range c.localNetworks {
+		if err := c.acceptInputToSubnet(ctx, network.InterfaceName, network.Subnet, remove); err != nil {
 			return fmt.Errorf("cannot enable firewall: %w", err)
 		}
 	}

--- a/internal/firewall/enable.go
+++ b/internal/firewall/enable.go
@@ -94,8 +94,10 @@ func (c *configurator) enable(ctx context.Context) (err error) {
 		return fmt.Errorf("cannot enable firewall: %w", err)
 	}
 
-	if err := c.acceptOutputFromIPToSubnet(ctx, c.defaultInterface, c.localIP, c.localSubnet, remove); err != nil {
-		return fmt.Errorf("cannot enable firewall: %w", err)
+	for _, subnet := range c.localSubnets {
+		if err := c.acceptOutputFromIPToSubnet(ctx, c.defaultInterface, c.localIP, subnet, remove); err != nil {
+			return fmt.Errorf("cannot enable firewall: %w", err)
+		}
 	}
 
 	for _, subnet := range c.outboundSubnets {
@@ -106,8 +108,10 @@ func (c *configurator) enable(ctx context.Context) (err error) {
 
 	// Allows packets from any IP address to go through eth0 / local network
 	// to reach Gluetun.
-	if err := c.acceptInputToSubnet(ctx, c.defaultInterface, c.localSubnet, remove); err != nil {
-		return fmt.Errorf("cannot enable firewall: %w", err)
+	for _, subnet := range c.localSubnets {
+		if err := c.acceptInputToSubnet(ctx, c.defaultInterface, subnet, remove); err != nil {
+			return fmt.Errorf("cannot enable firewall: %w", err)
+		}
 	}
 
 	for port, intf := range c.allowedInputPorts {

--- a/internal/firewall/firewall.go
+++ b/internal/firewall/firewall.go
@@ -24,7 +24,7 @@ type Configurator interface {
 	RemoveAllowedPort(ctx context.Context, port uint16) (err error)
 	SetDebug()
 	// SetNetworkInformation is meant to be called only once
-	SetNetworkInformation(defaultInterface string, defaultGateway net.IP, localSubnet net.IPNet, localIP net.IP)
+	SetNetworkInformation(defaultInterface string, defaultGateway net.IP, localSubnets []net.IPNet, localIP net.IP)
 }
 
 type configurator struct { //nolint:maligned
@@ -36,7 +36,7 @@ type configurator struct { //nolint:maligned
 	debug            bool
 	defaultInterface string
 	defaultGateway   net.IP
-	localSubnet      net.IPNet
+	localSubnets     []net.IPNet
 	localIP          net.IP
 	networkInfoMutex sync.Mutex
 
@@ -64,11 +64,11 @@ func (c *configurator) SetDebug() {
 }
 
 func (c *configurator) SetNetworkInformation(
-	defaultInterface string, defaultGateway net.IP, localSubnet net.IPNet, localIP net.IP) {
+	defaultInterface string, defaultGateway net.IP, localSubnets []net.IPNet, localIP net.IP) {
 	c.networkInfoMutex.Lock()
 	defer c.networkInfoMutex.Unlock()
 	c.defaultInterface = defaultInterface
 	c.defaultGateway = defaultGateway
-	c.localSubnet = localSubnet
+	c.localSubnets = localSubnets
 	c.localIP = localIP
 }

--- a/internal/firewall/firewall.go
+++ b/internal/firewall/firewall.go
@@ -24,7 +24,7 @@ type Configurator interface {
 	RemoveAllowedPort(ctx context.Context, port uint16) (err error)
 	SetDebug()
 	// SetNetworkInformation is meant to be called only once
-	SetNetworkInformation(defaultInterface string, defaultGateway net.IP, localSubnets []net.IPNet, localIP net.IP)
+	SetNetworkInformation(defaultInterface string, defaultGateway net.IP, localNetworks []routing.LocalNetwork, localIP net.IP)
 }
 
 type configurator struct { //nolint:maligned
@@ -36,7 +36,7 @@ type configurator struct { //nolint:maligned
 	debug            bool
 	defaultInterface string
 	defaultGateway   net.IP
-	localSubnets     []net.IPNet
+	localNetworks    []routing.LocalNetwork
 	localIP          net.IP
 	networkInfoMutex sync.Mutex
 
@@ -64,11 +64,11 @@ func (c *configurator) SetDebug() {
 }
 
 func (c *configurator) SetNetworkInformation(
-	defaultInterface string, defaultGateway net.IP, localSubnets []net.IPNet, localIP net.IP) {
+	defaultInterface string, defaultGateway net.IP, localNetworks []routing.LocalNetwork, localIP net.IP) {
 	c.networkInfoMutex.Lock()
 	defer c.networkInfoMutex.Unlock()
 	c.defaultInterface = defaultInterface
 	c.defaultGateway = defaultGateway
-	c.localSubnets = localSubnets
+	c.localNetworks = localNetworks
 	c.localIP = localIP
 }

--- a/internal/routing/reader.go
+++ b/internal/routing/reader.go
@@ -116,8 +116,6 @@ func (r *routing) LocalSubnets() (localSubnets []net.IPNet, err error) {
 		return localSubnets, fmt.Errorf("cannot list local routes: %w", err)
 	}
 
-	localSubnets = make([]net.IPNet, 0)
-
 	for _, route := range routes {
 		if route.Gw != nil || route.Dst == nil {
 			continue

--- a/internal/routing/reader.go
+++ b/internal/routing/reader.go
@@ -116,7 +116,7 @@ func (r *routing) LocalSubnets() (localSubnets []net.IPNet, err error) {
 		return localSubnets, fmt.Errorf("cannot list local routes: %w", err)
 	}
 
-	localSubnets = make([]net.IPNet, 1)
+	localSubnets = make([]net.IPNet, 0)
 
 	for _, route := range routes {
 		if route.Gw != nil || !localLinks[route.LinkIndex] {

--- a/internal/routing/reader.go
+++ b/internal/routing/reader.go
@@ -119,12 +119,12 @@ func (r *routing) LocalSubnets() (localSubnets []net.IPNet, err error) {
 			continue
 		}
 
-		localSubnet = *route.Dst
+		localSubnet := *route.Dst
 		if r.verbose {
 			r.logger.Info("local subnet found: %s", localSubnet.String())
 		}
 
-		append(localSubnets, localSubnet)
+		localSubnets = append(localSubnets, localSubnet)
 	}
 
 	if len(localSubnets) == 0 {

--- a/internal/routing/reader.go
+++ b/internal/routing/reader.go
@@ -88,6 +88,52 @@ func (r *routing) LocalSubnet() (defaultSubnet net.IPNet, err error) {
 	return defaultSubnet, fmt.Errorf("cannot find default subnet in %d routes", len(routes))
 }
 
+func (r *routing) LocalSubnets() (localSubnets []net.IPNet, err error) {
+    links, err := netlink.LinkList()
+    if err != nil {
+        return localSubnets, fmt.Errorf("cannot find local subnet: %w", err)
+    }
+
+    localLinks := make(map[int]bool)
+
+    for _, link := range links {
+        if link.Attrs().EncapType == "ether" {
+            localLinks[link.Attrs().Index] = true
+		    r.logger.Debug("local ethernet link found: %s", link.Attrs().Name)
+        }
+    }
+
+    if len(localLinks) == 0 {
+        return localSubnets, fmt.Errorf("cannot find any local interfaces")
+    }
+
+	routes, err := netlink.RouteList(nil, netlink.FAMILY_ALL)
+	if err != nil {
+		return localSubnets, fmt.Errorf("cannot list local routes: %w", err)
+	}
+
+	localSubnets = make([]net.IPNet, 1)
+
+	for _, route := range routes {
+		if route.Gw != nil || !localLinks[route.LinkIndex] {
+			continue
+		}
+
+		localSubnet = *route.Dst
+		if r.verbose {
+			r.logger.Info("local subnet found: %s", localSubnet.String())
+		}
+
+		append(localSubnets, localSubnet)
+	}
+
+	if len(localSubnets) == 0 {
+		return localSubnets, fmt.Errorf("cannot find any local subnets in %d routes", len(routes))
+	}
+
+	return localSubnets, nil
+}
+
 func (r *routing) assignedIP(interfaceName string) (ip net.IP, err error) {
 	iface, err := net.InterfaceByName(interfaceName)
 	if err != nil {

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -16,7 +16,7 @@ type Routing interface {
 
 	// Read only
 	DefaultRoute() (defaultInterface string, defaultGateway net.IP, err error)
-	LocalSubnets() (defaultSubnets []net.IPNet, err error)
+	LocalNetworks() (localNetworks []LocalNetwork, err error)
 	DefaultIP() (defaultIP net.IP, err error)
 	VPNDestinationIP() (ip net.IP, err error)
 	VPNLocalGatewayIP() (ip net.IP, err error)

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -16,7 +16,7 @@ type Routing interface {
 
 	// Read only
 	DefaultRoute() (defaultInterface string, defaultGateway net.IP, err error)
-	LocalSubnet() (defaultSubnet net.IPNet, err error)
+	LocalSubnets() (defaultSubnets []net.IPNet, err error)
 	DefaultIP() (defaultIP net.IP, err error)
 	VPNDestinationIP() (ip net.IP, err error)
 	VPNLocalGatewayIP() (ip net.IP, err error)


### PR DESCRIPTION
We cover all links that have their encapsulation set to 'ether' (in my testing this equated to all eth0/eth1/eth2/etc).

My assumption here is we'll be executing inside a docker container, and docker networks are exposed under eth0/eth1/etc, the openvpn tunnel and the local loopback don't have this so we automatically exclude them!

I think I've got it right, but haven't tested it yet (that's next), just raising now for any feedback/direction.

Fixes #411 

Cheers!