### PR TITLE
Feature/Bugfix: IPv6 blocking

### DIFF
--- a/internal/firewall/enable.go
+++ b/internal/firewall/enable.go
@@ -56,7 +56,7 @@ func (c *configurator) fallbackToDisabled(ctx context.Context) {
 	if ctx.Err() != nil {
 		return
 	}
-	if err := c.SetEnabled(ctx, false); err != nil {
+	if err := c.disable(ctx); err != nil {
 		c.logger.Error(err)
 	}
 }

--- a/internal/firewall/enable.go
+++ b/internal/firewall/enable.go
@@ -65,9 +65,11 @@ func (c *configurator) fallbackToDisabled(ctx context.Context) {
 }
 
 func (c *configurator) enable(ctx context.Context) (err error) {
+	touched := false
 	if err = c.setIPv4AllPolicies(ctx, "DROP"); err != nil {
 		return fmt.Errorf("cannot enable firewall: %w", err)
 	}
+	touched = true
 
 	if err = c.setIPv6AllPolicies(ctx, "DROP"); err != nil {
 		return fmt.Errorf("cannot enable firewall: %w", err)
@@ -76,7 +78,7 @@ func (c *configurator) enable(ctx context.Context) (err error) {
 	const remove = false
 
 	defer func() {
-		if err != nil {
+		if touched && err != nil {
 			c.fallbackToDisabled(ctx)
 		}
 	}()

--- a/internal/firewall/enable.go
+++ b/internal/firewall/enable.go
@@ -45,7 +45,10 @@ func (c *configurator) disable(ctx context.Context) (err error) {
 	if err = c.clearAllRules(ctx); err != nil {
 		return fmt.Errorf("cannot disable firewall: %w", err)
 	}
-	if err = c.setAllPolicies(ctx, "ACCEPT"); err != nil {
+	if err = c.setIPv4AllPolicies(ctx, "ACCEPT"); err != nil {
+		return fmt.Errorf("cannot disable firewall: %w", err)
+	}
+	if err = c.setIPv6AllPolicies(ctx, "ACCEPT"); err != nil {
 		return fmt.Errorf("cannot disable firewall: %w", err)
 	}
 	return nil
@@ -62,7 +65,11 @@ func (c *configurator) fallbackToDisabled(ctx context.Context) {
 }
 
 func (c *configurator) enable(ctx context.Context) (err error) {
-	if err = c.setAllPolicies(ctx, "DROP"); err != nil {
+	if err = c.setIPv4AllPolicies(ctx, "DROP"); err != nil {
+		return fmt.Errorf("cannot enable firewall: %w", err)
+	}
+
+	if err = c.setIPv6AllPolicies(ctx, "DROP"); err != nil {
 		return fmt.Errorf("cannot enable firewall: %w", err)
 	}
 

--- a/internal/firewall/firewall.go
+++ b/internal/firewall/firewall.go
@@ -34,6 +34,7 @@ type configurator struct { //nolint:maligned
 	routing          routing.Routing
 	openFile         os.OpenFileFunc // for custom iptables rules
 	iptablesMutex    sync.Mutex
+	ip6tablesMutex   sync.Mutex
 	debug            bool
 	defaultInterface string
 	defaultGateway   net.IP

--- a/internal/firewall/ip6tables.go
+++ b/internal/firewall/ip6tables.go
@@ -1,0 +1,42 @@
+package firewall
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+func (c *configurator) runIP6tablesInstructions(ctx context.Context, instructions []string) error {
+	for _, instruction := range instructions {
+		if err := c.runIP6tablesInstruction(ctx, instruction); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *configurator) runIP6tablesInstruction(ctx context.Context, instruction string) error {
+	c.ip6tablesMutex.Lock() // only one ip6tables command at once
+	defer c.ip6tablesMutex.Unlock()
+	if c.debug {
+		fmt.Println("ip6tables " + instruction)
+	}
+	flags := strings.Fields(instruction)
+	if output, err := c.commander.Run(ctx, "ip6tables", flags...); err != nil {
+		return fmt.Errorf("failed executing \"ip6tables %s\": %s: %w", instruction, output, err)
+	}
+	return nil
+}
+
+func (c *configurator) setIPv6AllPolicies(ctx context.Context, policy string) error {
+	switch policy {
+	case "ACCEPT", "DROP":
+	default:
+		return fmt.Errorf("policy %q not recognized", policy)
+	}
+	return c.runIP6tablesInstructions(ctx, []string{
+		"--policy INPUT " + policy,
+		"--policy OUTPUT " + policy,
+		"--policy FORWARD " + policy,
+	})
+}

--- a/internal/firewall/ip6tables.go
+++ b/internal/firewall/ip6tables.go
@@ -2,8 +2,13 @@ package firewall
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+)
+
+var (
+	ErrIP6Tables = errors.New("failed ip6tables command")
 )
 
 func (c *configurator) runIP6tablesInstructions(ctx context.Context, instructions []string) error {
@@ -23,7 +28,7 @@ func (c *configurator) runIP6tablesInstruction(ctx context.Context, instruction 
 	}
 	flags := strings.Fields(instruction)
 	if output, err := c.commander.Run(ctx, "ip6tables", flags...); err != nil {
-		return fmt.Errorf("failed executing \"ip6tables %s\": %s: %w", instruction, output, err)
+		return fmt.Errorf("%w \"ip6tables %s\": %s: %s", ErrIP6Tables, instruction, output, err)
 	}
 	return nil
 }

--- a/internal/firewall/iptables.go
+++ b/internal/firewall/iptables.go
@@ -71,49 +71,56 @@ func (c *configurator) runIptablesInstruction(ctx context.Context, instruction s
 }
 
 func (c *configurator) clearAllRules(ctx context.Context) error {
-	return c.runIptablesInstructions(ctx, []string{
+	return c.runMixedIptablesInstructions(ctx, []string{
 		"--flush",        // flush all chains
 		"--delete-chain", // delete all chains
 	})
 }
 
-func (c *configurator) setAllPolicies(ctx context.Context, policy string) error {
+func (c *configurator) setIPv4AllPolicies(ctx context.Context, policy string) error {
 	switch policy {
 	case "ACCEPT", "DROP":
 	default:
 		return fmt.Errorf("policy %q not recognized", policy)
 	}
 	return c.runIptablesInstructions(ctx, []string{
-		fmt.Sprintf("--policy INPUT %s", policy),
-		fmt.Sprintf("--policy OUTPUT %s", policy),
-		fmt.Sprintf("--policy FORWARD %s", policy),
+		"--policy INPUT " + policy,
+		"--policy OUTPUT " + policy,
+		"--policy FORWARD " + policy,
 	})
 }
 
 func (c *configurator) acceptInputThroughInterface(ctx context.Context, intf string, remove bool) error {
-	return c.runIptablesInstruction(ctx, fmt.Sprintf(
+	return c.runMixedIptablesInstruction(ctx, fmt.Sprintf(
 		"%s INPUT -i %s -j ACCEPT", appendOrDelete(remove), intf,
 	))
 }
 
 func (c *configurator) acceptInputToSubnet(ctx context.Context, intf string, destination net.IPNet, remove bool) error {
+	isIP4Subnet := destination.IP.To4() != nil
+
 	interfaceFlag := "-i " + intf
 	if intf == "*" { // all interfaces
 		interfaceFlag = ""
 	}
-	return c.runIptablesInstruction(ctx, fmt.Sprintf(
-		"%s INPUT %s -d %s -j ACCEPT", appendOrDelete(remove), interfaceFlag, destination.String(),
-	))
+
+	instruction := fmt.Sprintf("%s INPUT %s -d %s -j ACCEPT",
+		appendOrDelete(remove), interfaceFlag, destination.String())
+
+	if isIP4Subnet {
+		return c.runIptablesInstruction(ctx, instruction)
+	}
+	return c.runIP6tablesInstruction(ctx, instruction)
 }
 
 func (c *configurator) acceptOutputThroughInterface(ctx context.Context, intf string, remove bool) error {
-	return c.runIptablesInstruction(ctx, fmt.Sprintf(
+	return c.runMixedIptablesInstruction(ctx, fmt.Sprintf(
 		"%s OUTPUT -o %s -j ACCEPT", appendOrDelete(remove), intf,
 	))
 }
 
 func (c *configurator) acceptEstablishedRelatedTraffic(ctx context.Context, remove bool) error {
-	return c.runIptablesInstructions(ctx, []string{
+	return c.runMixedIptablesInstructions(ctx, []string{
 		fmt.Sprintf("%s OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT", appendOrDelete(remove)),
 		fmt.Sprintf("%s INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT", appendOrDelete(remove)),
 	})
@@ -121,22 +128,33 @@ func (c *configurator) acceptEstablishedRelatedTraffic(ctx context.Context, remo
 
 func (c *configurator) acceptOutputTrafficToVPN(ctx context.Context,
 	defaultInterface string, connection models.OpenVPNConnection, remove bool) error {
-	return c.runIptablesInstruction(ctx,
-		fmt.Sprintf("%s OUTPUT -d %s -o %s -p %s -m %s --dport %d -j ACCEPT",
-			appendOrDelete(remove), connection.IP, defaultInterface, connection.Protocol, connection.Protocol, connection.Port))
+	instruction := fmt.Sprintf("%s OUTPUT -d %s -o %s -p %s -m %s --dport %d -j ACCEPT",
+		appendOrDelete(remove), connection.IP, defaultInterface, connection.Protocol,
+		connection.Protocol, connection.Port)
+	isIPv4 := connection.IP.To4() != nil
+	if isIPv4 {
+		return c.runIptablesInstruction(ctx, instruction)
+	}
+	return c.runIP6tablesInstruction(ctx, instruction)
 }
 
 // Thanks to @npawelek.
 func (c *configurator) acceptOutputFromIPToSubnet(ctx context.Context,
 	intf string, sourceIP net.IP, destinationSubnet net.IPNet, remove bool) error {
+	doIPv4 := sourceIP.To4() != nil && destinationSubnet.IP.To4() != nil
+
 	interfaceFlag := "-o " + intf
 	if intf == "*" { // all interfaces
 		interfaceFlag = ""
 	}
-	return c.runIptablesInstruction(ctx, fmt.Sprintf(
-		"%s OUTPUT %s -s %s -d %s -j ACCEPT",
-		appendOrDelete(remove), interfaceFlag, sourceIP.String(), destinationSubnet.String(),
-	))
+
+	instruction := fmt.Sprintf("%s OUTPUT %s -s %s -d %s -j ACCEPT",
+		appendOrDelete(remove), interfaceFlag, sourceIP.String(), destinationSubnet.String())
+
+	if doIPv4 {
+		return c.runIptablesInstruction(ctx, instruction)
+	}
+	return c.runIP6tablesInstruction(ctx, instruction)
 }
 
 // Used for port forwarding, with intf set to tun.
@@ -145,12 +163,13 @@ func (c *configurator) acceptInputToPort(ctx context.Context, intf string, port 
 	if intf == "*" { // all interfaces
 		interfaceFlag = ""
 	}
-	return c.runIptablesInstructions(ctx, []string{
+	return c.runMixedIptablesInstructions(ctx, []string{
 		fmt.Sprintf("%s INPUT %s -p tcp --dport %d -j ACCEPT", appendOrDelete(remove), interfaceFlag, port),
 		fmt.Sprintf("%s INPUT %s -p udp --dport %d -j ACCEPT", appendOrDelete(remove), interfaceFlag, port),
 	})
 }
 
+// runUserPostRules only runs instructions for iptables
 func (c *configurator) runUserPostRules(ctx context.Context, filepath string, remove bool) error {
 	file, err := c.openFile(filepath, os.O_RDONLY, 0)
 	if os.IsNotExist(err) {
@@ -178,16 +197,32 @@ func (c *configurator) runUserPostRules(ctx context.Context, filepath string, re
 		}
 	}()
 	for _, line := range lines {
-		if !strings.HasPrefix(line, "iptables ") {
+		var ipv4 bool
+		var rule string
+		switch {
+		case strings.HasPrefix(line, "iptables "):
+			ipv4 = true
+			rule = strings.TrimPrefix(line, "iptables ")
+		case strings.HasPrefix(line, "ip6tables "):
+			ipv4 = false
+			rule = strings.TrimPrefix(line, "ip6tables ")
+		default:
 			continue
 		}
-		rule := strings.TrimPrefix(line, "iptables ")
+
 		if remove {
 			rule = flipRule(rule)
 		}
-		if err = c.runIptablesInstruction(ctx, rule); err != nil {
+
+		if ipv4 {
+			err = c.runIptablesInstruction(ctx, rule)
+		} else {
+			err = c.runIP6tablesInstruction(ctx, rule)
+		}
+		if err != nil {
 			return fmt.Errorf("cannot run custom rule: %w", err)
 		}
+
 		successfulRules = append(successfulRules, rule)
 	}
 	return nil

--- a/internal/firewall/iptablesmix.go
+++ b/internal/firewall/iptablesmix.go
@@ -1,0 +1,21 @@
+package firewall
+
+import (
+	"context"
+)
+
+func (c *configurator) runMixedIptablesInstructions(ctx context.Context, instructions []string) error {
+	for _, instruction := range instructions {
+		if err := c.runMixedIptablesInstruction(ctx, instruction); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *configurator) runMixedIptablesInstruction(ctx context.Context, instruction string) error {
+	if err := c.runIptablesInstruction(ctx, instruction); err != nil {
+		return err
+	}
+	return c.runIP6tablesInstruction(ctx, instruction)
+}


### PR DESCRIPTION
- Feature/Bugfix: Block all IPv6 traffic with `ip6tables` by default
- Feature: Adapt existing firewall code to handle IPv4 and IPv6, depending on user inputs and environment
- Maintenance: improve error wrapping in the firewall package