### PR TITLE
`LOG_LEVEL` variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ LABEL \
     org.opencontainers.image.description="VPN swiss-knife like client to tunnel to multiple VPN servers using OpenVPN, IPtables, DNS over TLS, Shadowsocks, an HTTP proxy and Alpine Linux"
 ENV VPNSP=pia \
     VERSION_INFORMATION=on \
+    LOG_LEVEL=info \
     VPN_TYPE=openvpn \
     PROTOCOL=udp \
     OPENVPN_VERSION=2.5 \

--- a/cmd/gluetun/main.go
+++ b/cmd/gluetun/main.go
@@ -141,6 +141,7 @@ func _main(ctx context.Context, buildInfo models.BuildInformation,
 	if err != nil {
 		return err
 	}
+	logger.PatchLevel(allSettings.Log.Level)
 
 	puid, pgid := allSettings.System.PUID, allSettings.System.PGID
 

--- a/internal/configuration/log.go
+++ b/internal/configuration/log.go
@@ -1,0 +1,30 @@
+package configuration
+
+import (
+	"fmt"
+
+	"github.com/qdm12/golibs/logging"
+	"github.com/qdm12/golibs/params"
+)
+
+type Log struct {
+	Level logging.Level `json:"level"`
+}
+
+func (settings *Log) lines() (lines []string) {
+	lines = append(lines, lastIndent+"Log:")
+
+	lines = append(lines, indent+lastIndent+"Level: "+settings.Level.String())
+
+	return lines
+}
+
+func (settings *Log) read(env params.Env) (err error) {
+	defaultLevel := logging.LevelInfo.String()
+	settings.Level, err = env.LogLevel("LOG_LEVEL", params.Default(defaultLevel))
+	if err != nil {
+		return fmt.Errorf("environment variable LOG_LEVEL: %w", err)
+	}
+
+	return nil
+}

--- a/internal/configuration/log.go
+++ b/internal/configuration/log.go
@@ -19,7 +19,7 @@ func (settings *Log) lines() (lines []string) {
 	return lines
 }
 
-func (settings *Log) read(env params.Env) (err error) {
+func (settings *Log) read(env params.Interface) (err error) {
 	defaultLevel := logging.LevelInfo.String()
 	settings.Level, err = env.LogLevel("LOG_LEVEL", params.Default(defaultLevel))
 	if err != nil {

--- a/internal/configuration/settings.go
+++ b/internal/configuration/settings.go
@@ -22,6 +22,7 @@ type Settings struct {
 	VersionInformation bool
 	ControlServer      ControlServer
 	Health             Health
+	Log                Log
 }
 
 func (settings *Settings) String() string {
@@ -33,6 +34,7 @@ func (settings *Settings) lines() (lines []string) {
 	lines = append(lines, settings.VPN.lines()...)
 	lines = append(lines, settings.DNS.lines()...)
 	lines = append(lines, settings.Firewall.lines()...)
+	lines = append(lines, settings.Log.lines()...)
 	lines = append(lines, settings.System.lines()...)
 	lines = append(lines, settings.HTTPProxy.lines()...)
 	lines = append(lines, settings.ShadowSocks.lines()...)
@@ -57,6 +59,7 @@ var (
 	ErrUpdater       = errors.New("cannot read Updater settings")
 	ErrPublicIP      = errors.New("cannot read Public IP getter settings")
 	ErrHealth        = errors.New("cannot read health settings")
+	ErrLog           = errors.New("cannot read log settings")
 )
 
 // Read obtains all configuration options for the program and returns an error as soon
@@ -111,6 +114,10 @@ func (settings *Settings) Read(env params.Interface, logger logging.Logger) (err
 
 	if err := settings.Health.read(r); err != nil {
 		return fmt.Errorf("%w: %s", ErrHealth, err)
+	}
+
+	if err := settings.Log.read(r.env); err != nil {
+		return fmt.Errorf("%w: %s", ErrLog, err)
 	}
 
 	return nil

--- a/internal/configuration/settings_test.go
+++ b/internal/configuration/settings_test.go
@@ -43,6 +43,8 @@ func Test_Settings_lines(t *testing.T) {
 				"         |--Protocol: udp",
 				"|--DNS:",
 				"|--Firewall: disabled ⚠️",
+				"|--Log:",
+				"   |--Level: DEBUG",
 				"|--System:",
 				"   |--Process user ID: 0",
 				"   |--Process group ID: 0",


### PR DESCRIPTION
- [x] Read `LOG_LEVEL` variable in `allSettings`

- [ ] Read and inject `allSettings` in `_main()` in another PR, such that the parent logger can be set with the right level at start

or

- [x] Add a method to the logger to change settings (with mutex) such that the log level can be changed