### PR TITLE
add line to compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ version: "3"
 services:
   gluetun:
     image: qmcgaw/gluetun
-    container_name: gluetun
+    # container_name: gluetun
+    # line above must be uncommented to allow external containers to connect. See https://github.com/qdm12/gluetun/wiki/Connect-a-container-to-gluetun#external-container-to-gluetun
     cap_add:
       - NET_ADMIN
     ports:

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ version: "3"
 services:
   gluetun:
     image: qmcgaw/gluetun
+    container_name: gluetun
     cap_add:
       - NET_ADMIN
     ports:


### PR DESCRIPTION
container_name is required to correctly refer to gluetun container from a different compose file