### PR TITLE
Enable ipv6 connection & tunneling

### DIFF
--- a/internal/firewall/enable.go
+++ b/internal/firewall/enable.go
@@ -101,6 +101,9 @@ func (c *Config) enable(ctx context.Context) (err error) {
 		if err := c.acceptOutputFromIPToSubnet(ctx, network.InterfaceName, network.IP, *network.IPNet, remove); err != nil {
 			return err
 		}
+		if err = c.acceptIpv6MulticastOutput(ctx, network.InterfaceName, remove); err != nil {
+			return err
+		}
 	}
 
 	if err = c.allowOutboundSubnets(ctx); err != nil {

--- a/internal/firewall/iptables.go
+++ b/internal/firewall/iptables.go
@@ -179,6 +179,7 @@ func (c *Config) acceptOutputFromIPToSubnet(ctx context.Context,
 	return c.runIP6tablesInstruction(ctx, instruction)
 }
 
+// NDP uses multicast address (theres no broadcast in IPv6 like ARP uses in IPv4).
 func (c *Config) acceptIpv6MulticastOutput(ctx context.Context,
 	intf string, remove bool) error {
 	interfaceFlag := "-o " + intf

--- a/internal/firewall/iptables.go
+++ b/internal/firewall/iptables.go
@@ -185,7 +185,7 @@ func (c *Config) acceptIpv6MulticastOutput(ctx context.Context,
 	if intf == "*" { // all interfaces
 		interfaceFlag = ""
 	}
-	instruction := fmt.Sprintf("%s OUTPUT %s -d ff00::/8 -j ACCEPT",
+	instruction := fmt.Sprintf("%s OUTPUT %s -d ff02::1:ff/104 -j ACCEPT",
 		appendOrDelete(remove), interfaceFlag)
 	return c.runIP6tablesInstruction(ctx, instruction)
 }

--- a/internal/firewall/iptables.go
+++ b/internal/firewall/iptables.go
@@ -179,6 +179,17 @@ func (c *Config) acceptOutputFromIPToSubnet(ctx context.Context,
 	return c.runIP6tablesInstruction(ctx, instruction)
 }
 
+func (c *Config) acceptIpv6MulticastOutput(ctx context.Context,
+	intf string, remove bool) error {
+	interfaceFlag := "-o " + intf
+	if intf == "*" { // all interfaces
+		interfaceFlag = ""
+	}
+	instruction := fmt.Sprintf("%s OUTPUT %s -d ff00::/8 -j ACCEPT",
+		appendOrDelete(remove), interfaceFlag)
+	return c.runIP6tablesInstruction(ctx, instruction)
+}
+
 // Used for port forwarding, with intf set to tun.
 func (c *Config) acceptInputToPort(ctx context.Context, intf string, port uint16, remove bool) error {
 	interfaceFlag := "-i " + intf

--- a/internal/firewall/iptablesmix.go
+++ b/internal/firewall/iptablesmix.go
@@ -14,8 +14,8 @@ func (c *Config) runMixedIptablesInstructions(ctx context.Context, instructions 
 }
 
 func (c *Config) runMixedIptablesInstruction(ctx context.Context, instruction string) error {
-	if err := c.runIptablesInstruction(ctx, instruction); err != nil {
+	if err := c.runIP6tablesInstruction(ctx, instruction); err != nil {
 		return err
 	}
-	return c.runIP6tablesInstruction(ctx, instruction)
+	return c.runIptablesInstruction(ctx, instruction)
 }

--- a/internal/firewall/iptablesmix.go
+++ b/internal/firewall/iptablesmix.go
@@ -14,8 +14,8 @@ func (c *Config) runMixedIptablesInstructions(ctx context.Context, instructions 
 }
 
 func (c *Config) runMixedIptablesInstruction(ctx context.Context, instruction string) error {
-	if err := c.runIP6tablesInstruction(ctx, instruction); err != nil {
+	if err := c.runIptablesInstruction(ctx, instruction); err != nil {
 		return err
 	}
-	return c.runIptablesInstruction(ctx, instruction)
+	return c.runIP6tablesInstruction(ctx, instruction)
 }

--- a/internal/routing/default.go
+++ b/internal/routing/default.go
@@ -43,8 +43,11 @@ func (r *Routing) DefaultRoutes() (defaultRoutes []DefaultRoute, err error) {
 			}
 			attributes := link.Attrs()
 			defaultRoute.NetInterface = attributes.Name
-
-			defaultRoute.AssignedIP, err = r.assignedIP(defaultRoute.NetInterface)
+			family := netlink.FAMILY_V6
+			if route.Gw.To4() != nil {
+				family = netlink.FAMILY_V4
+			}
+			defaultRoute.AssignedIP, err = r.assignedIP(defaultRoute.NetInterface, family)
 			if err != nil {
 				return nil, fmt.Errorf("cannot get assigned IP of %s: %w", defaultRoute.NetInterface, err)
 			}

--- a/internal/routing/ip.go
+++ b/internal/routing/ip.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+
+	"github.com/qdm12/gluetun/internal/netlink"
 )
 
 func IPIsPrivate(ip net.IP) bool {
@@ -15,7 +17,7 @@ var (
 	errInterfaceIPNotFound = errors.New("IP address not found for interface")
 )
 
-func (r *Routing) assignedIP(interfaceName string) (ip net.IP, err error) {
+func (r *Routing) assignedIP(interfaceName string, family int) (ip net.IP, err error) {
 	iface, err := net.InterfaceByName(interfaceName)
 	if err != nil {
 		return nil, fmt.Errorf("network interface %s not found: %w", interfaceName, err)
@@ -27,9 +29,15 @@ func (r *Routing) assignedIP(interfaceName string) (ip net.IP, err error) {
 	for _, address := range addresses {
 		switch value := address.(type) {
 		case *net.IPAddr:
-			return value.IP, nil
+			if (family == netlink.FAMILY_V6 && value.IP.To4() == nil) ||
+				(family == netlink.FAMILY_V4 && value.IP.To4() != nil) {
+				return value.IP, nil
+			}
 		case *net.IPNet:
-			return value.IP, nil
+			if (family == netlink.FAMILY_V6 && value.IP.To4() == nil) ||
+				(family == netlink.FAMILY_V4 && value.IP.To4() != nil) {
+				return value.IP, nil
+			}
 		}
 	}
 	return nil, fmt.Errorf("%w: interface %s in %d addresses",

--- a/internal/routing/ip.go
+++ b/internal/routing/ip.go
@@ -17,6 +17,14 @@ var (
 	errInterfaceIPNotFound = errors.New("IP address not found for interface")
 )
 
+func ipMatchesFamily(ip net.IP, family int) bool {
+	if (family == netlink.FAMILY_V6 && ip.To4() == nil) ||
+		(family == netlink.FAMILY_V4 && ip.To4() != nil) {
+		return true
+	}
+	return false
+}
+
 func (r *Routing) assignedIP(interfaceName string, family int) (ip net.IP, err error) {
 	iface, err := net.InterfaceByName(interfaceName)
 	if err != nil {
@@ -29,13 +37,11 @@ func (r *Routing) assignedIP(interfaceName string, family int) (ip net.IP, err e
 	for _, address := range addresses {
 		switch value := address.(type) {
 		case *net.IPAddr:
-			if (family == netlink.FAMILY_V6 && value.IP.To4() == nil) ||
-				(family == netlink.FAMILY_V4 && value.IP.To4() != nil) {
+			if ipMatchesFamily(value.IP, family) {
 				return value.IP, nil
 			}
 		case *net.IPNet:
-			if (family == netlink.FAMILY_V6 && value.IP.To4() == nil) ||
-				(family == netlink.FAMILY_V4 && value.IP.To4() != nil) {
+			if ipMatchesFamily(value.IP, family) {
 				return value.IP, nil
 			}
 		}

--- a/internal/routing/ip.go
+++ b/internal/routing/ip.go
@@ -18,11 +18,8 @@ var (
 )
 
 func ipMatchesFamily(ip net.IP, family int) bool {
-	if (family == netlink.FAMILY_V6 && ip.To4() == nil) ||
-		(family == netlink.FAMILY_V4 && ip.To4() != nil) {
-		return true
-	}
-	return false
+	return (family == netlink.FAMILY_V6 && ip.To4() == nil) ||
+		(family == netlink.FAMILY_V4 && ip.To4() != nil)
 }
 
 func (r *Routing) assignedIP(interfaceName string, family int) (ip net.IP, err error) {

--- a/internal/routing/local.go
+++ b/internal/routing/local.go
@@ -41,7 +41,7 @@ func (r *Routing) LocalNetworks() (localNetworks []LocalNetwork, err error) {
 		return localNetworks, fmt.Errorf("%w: in %d links", ErrLinkLocalNotFound, len(links))
 	}
 
-	routes, err := r.netLinker.RouteList(nil, netlink.FAMILY_V4)
+	routes, err := r.netLinker.RouteList(nil, netlink.FAMILY_ALL)
 	if err != nil {
 		return localNetworks, fmt.Errorf("cannot list routes: %w", err)
 	}
@@ -65,7 +65,11 @@ func (r *Routing) LocalNetworks() (localNetworks []LocalNetwork, err error) {
 
 		localNet.InterfaceName = link.Attrs().Name
 
-		ip, err := r.assignedIP(localNet.InterfaceName)
+		family := netlink.FAMILY_V6
+		if localNet.IPNet.IP.To4() != nil {
+			family = netlink.FAMILY_V4
+		}
+		ip, err := r.assignedIP(localNet.InterfaceName, family)
 		if err != nil {
 			return localNetworks, err
 		}

--- a/internal/wireguard/netlink_integration_test.go
+++ b/internal/wireguard/netlink_integration_test.go
@@ -108,12 +108,12 @@ func Test_netlink_Wireguard_addRule4(t *testing.T) {
 	assert.Equal(t, expectedRule, rule)
 
 	// Existing rule cannot be added
-	nilCleanup, err := wg.addRule(rulePriority, firewallMark)
+	nilCleanup, err := wg.addRule4(rulePriority, firewallMark)
 	if nilCleanup != nil {
 		_ = nilCleanup() // in case it succeeds
 	}
 	require.Error(t, err)
-	assert.Equal(t, "file exists: when adding rule: ip rule 10000: from <nil> table 999", err.Error())
+	assert.Equal(t, "cannot add rule ip rule 10000: from all to all table 999: file exists", err.Error())
 }
 
 func Test_netlink_Wireguard_addRule6(t *testing.T) {
@@ -128,6 +128,13 @@ func Test_netlink_Wireguard_addRule6(t *testing.T) {
 	const firewallMark = 999
 
 	cleanup, err := wg.addRule6(rulePriority, firewallMark)
+	if err != nil {
+		// IPv6 not supported
+		const errMessageIPv6NotSupported = "cannot add rule ip rule 10000: from all to all table 999: address family not supported by protocol"
+		assert.EqualError(t, err, errMessageIPv6NotSupported)
+		return
+	}
+
 	require.NoError(t, err)
 	defer func() {
 		err := cleanup()
@@ -159,7 +166,7 @@ func Test_netlink_Wireguard_addRule6(t *testing.T) {
 	assert.Equal(t, expectedRule, rule)
 
 	// Existing rule cannot be added
-	nilCleanup, err := wg.addRule(rulePriority, firewallMark)
+	nilCleanup, err := wg.addRule4(rulePriority, firewallMark)
 	if nilCleanup != nil {
 		_ = nilCleanup() // in case it succeeds
 	}

--- a/internal/wireguard/netlink_integration_test.go
+++ b/internal/wireguard/netlink_integration_test.go
@@ -76,7 +76,7 @@ func Test_netlink_Wireguard_addRule(t *testing.T) {
 	rulePriority := 10000
 	const firewallMark = 999
 
-	cleanup, err := wg.addRule(rulePriority, firewallMark)
+	cleanup, err := wg.addRule4(rulePriority, firewallMark)
 	require.NoError(t, err)
 	defer func() {
 		err := cleanup()

--- a/internal/wireguard/rule.go
+++ b/internal/wireguard/rule.go
@@ -4,39 +4,16 @@ import (
 	"fmt"
 
 	"github.com/qdm12/gluetun/internal/netlink"
-	"golang.org/x/sys/unix"
 )
 
-func (w *Wireguard) addRule4(rulePriority, firewallMark int) (
+func (w *Wireguard) addRule(rulePriority, firewallMark, family int) (
 	cleanup func() error, err error) {
 	rule := netlink.NewRule()
 	rule.Invert = true
 	rule.Priority = rulePriority
 	rule.Mark = firewallMark
 	rule.Table = firewallMark
-	rule.Family = unix.AF_INET
-	if err := w.netlink.RuleAdd(rule); err != nil {
-		return nil, fmt.Errorf("cannot add rule %s: %w", rule, err)
-	}
-
-	cleanup = func() error {
-		err := w.netlink.RuleDel(rule)
-		if err != nil {
-			return fmt.Errorf("cannot delete rule %s: %w", rule, err)
-		}
-		return nil
-	}
-	return cleanup, nil
-}
-
-func (w *Wireguard) addRule6(rulePriority, firewallMark int) (
-	cleanup func() error, err error) {
-	rule := netlink.NewRule()
-	rule.Invert = true
-	rule.Priority = rulePriority
-	rule.Mark = firewallMark
-	rule.Table = firewallMark
-	rule.Family = unix.AF_INET6
+	rule.Family = family
 	if err := w.netlink.RuleAdd(rule); err != nil {
 		return nil, fmt.Errorf("cannot add rule %s: %w", rule, err)
 	}

--- a/internal/wireguard/rule.go
+++ b/internal/wireguard/rule.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/qdm12/gluetun/internal/netlink"
+	"golang.org/x/sys/unix"
 )
 
 func (w *Wireguard) addRule(rulePriority, firewallMark int) (
@@ -13,6 +14,29 @@ func (w *Wireguard) addRule(rulePriority, firewallMark int) (
 	rule.Priority = rulePriority
 	rule.Mark = firewallMark
 	rule.Table = firewallMark
+	rule.Family = unix.AF_INET //nolint:all
+	if err := w.netlink.RuleAdd(rule); err != nil {
+		return nil, fmt.Errorf("cannot add rule %s: %w", rule, err)
+	}
+
+	cleanup = func() error {
+		err := w.netlink.RuleDel(rule)
+		if err != nil {
+			return fmt.Errorf("cannot delete rule %s: %w", rule, err)
+		}
+		return nil
+	}
+	return cleanup, nil
+}
+
+func (w *Wireguard) addRule6(rulePriority, firewallMark int) (
+	cleanup func() error, err error) {
+	rule := netlink.NewRule()
+	rule.Invert = true
+	rule.Priority = rulePriority
+	rule.Mark = firewallMark
+	rule.Table = firewallMark
+	rule.Family = unix.AF_INET6 //nolint:all
 	if err := w.netlink.RuleAdd(rule); err != nil {
 		return nil, fmt.Errorf("cannot add rule %s: %w", rule, err)
 	}

--- a/internal/wireguard/rule.go
+++ b/internal/wireguard/rule.go
@@ -7,14 +7,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func (w *Wireguard) addRule(rulePriority, firewallMark int) (
+func (w *Wireguard) addRule4(rulePriority, firewallMark int) (
 	cleanup func() error, err error) {
 	rule := netlink.NewRule()
 	rule.Invert = true
 	rule.Priority = rulePriority
 	rule.Mark = firewallMark
 	rule.Table = firewallMark
-	rule.Family = unix.AF_INET //nolint:all
+	rule.Family = unix.AF_INET //nolint:nosnakecase
 	if err := w.netlink.RuleAdd(rule); err != nil {
 		return nil, fmt.Errorf("cannot add rule %s: %w", rule, err)
 	}
@@ -36,7 +36,7 @@ func (w *Wireguard) addRule6(rulePriority, firewallMark int) (
 	rule.Priority = rulePriority
 	rule.Mark = firewallMark
 	rule.Table = firewallMark
-	rule.Family = unix.AF_INET6 //nolint:all
+	rule.Family = unix.AF_INET6 //nolint:nosnakecase
 	if err := w.netlink.RuleAdd(rule); err != nil {
 		return nil, fmt.Errorf("cannot add rule %s: %w", rule, err)
 	}

--- a/internal/wireguard/rule.go
+++ b/internal/wireguard/rule.go
@@ -14,7 +14,7 @@ func (w *Wireguard) addRule4(rulePriority, firewallMark int) (
 	rule.Priority = rulePriority
 	rule.Mark = firewallMark
 	rule.Table = firewallMark
-	rule.Family = unix.AF_INET //nolint:nosnakecase
+	rule.Family = unix.AF_INET
 	if err := w.netlink.RuleAdd(rule); err != nil {
 		return nil, fmt.Errorf("cannot add rule %s: %w", rule, err)
 	}
@@ -36,7 +36,7 @@ func (w *Wireguard) addRule6(rulePriority, firewallMark int) (
 	rule.Priority = rulePriority
 	rule.Mark = firewallMark
 	rule.Table = firewallMark
-	rule.Family = unix.AF_INET6 //nolint:nosnakecase
+	rule.Family = unix.AF_INET6
 	if err := w.netlink.RuleAdd(rule); err != nil {
 		return nil, fmt.Errorf("cannot add rule %s: %w", rule, err)
 	}

--- a/internal/wireguard/rule_test.go
+++ b/internal/wireguard/rule_test.go
@@ -8,9 +8,10 @@ import (
 	"github.com/qdm12/gluetun/internal/netlink"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
-func Test_Wireguard_addRule(t *testing.T) {
+func Test_Wireguard_addRule4(t *testing.T) {
 	t.Parallel()
 
 	const rulePriority = 987
@@ -36,6 +37,7 @@ func Test_Wireguard_addRule(t *testing.T) {
 				Flow:              -1,
 				SuppressIfgroup:   -1,
 				SuppressPrefixlen: -1,
+				Family:            unix.AF_INET,
 			},
 		},
 		"rule add error": {
@@ -49,6 +51,7 @@ func Test_Wireguard_addRule(t *testing.T) {
 				Flow:              -1,
 				SuppressIfgroup:   -1,
 				SuppressPrefixlen: -1,
+				Family:            unix.AF_INET,
 			},
 			ruleAddErr: errDummy,
 			err:        errors.New("cannot add rule ip rule 987: from all to all table 456: dummy"),
@@ -64,6 +67,7 @@ func Test_Wireguard_addRule(t *testing.T) {
 				Flow:              -1,
 				SuppressIfgroup:   -1,
 				SuppressPrefixlen: -1,
+				Family:            unix.AF_INET,
 			},
 			ruleDelErr: errDummy,
 			cleanupErr: errors.New("cannot delete rule ip rule 987: from all to all table 456: dummy"),

--- a/internal/wireguard/rule_test.go
+++ b/internal/wireguard/rule_test.go
@@ -11,11 +11,12 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func Test_Wireguard_addRule4(t *testing.T) {
+func Test_Wireguard_addRule(t *testing.T) {
 	t.Parallel()
 
 	const rulePriority = 987
 	const firewallMark = 456
+	const family = unix.AF_INET
 
 	errDummy := errors.New("dummy")
 
@@ -37,7 +38,7 @@ func Test_Wireguard_addRule4(t *testing.T) {
 				Flow:              -1,
 				SuppressIfgroup:   -1,
 				SuppressPrefixlen: -1,
-				Family:            unix.AF_INET,
+				Family:            family,
 			},
 		},
 		"rule add error": {
@@ -51,7 +52,7 @@ func Test_Wireguard_addRule4(t *testing.T) {
 				Flow:              -1,
 				SuppressIfgroup:   -1,
 				SuppressPrefixlen: -1,
-				Family:            unix.AF_INET,
+				Family:            family,
 			},
 			ruleAddErr: errDummy,
 			err:        errors.New("cannot add rule ip rule 987: from all to all table 456: dummy"),
@@ -67,7 +68,7 @@ func Test_Wireguard_addRule4(t *testing.T) {
 				Flow:              -1,
 				SuppressIfgroup:   -1,
 				SuppressPrefixlen: -1,
-				Family:            unix.AF_INET,
+				Family:            family,
 			},
 			ruleDelErr: errDummy,
 			cleanupErr: errors.New("cannot delete rule ip rule 987: from all to all table 456: dummy"),
@@ -87,7 +88,7 @@ func Test_Wireguard_addRule4(t *testing.T) {
 
 			netLinker.EXPECT().RuleAdd(testCase.expectedRule).
 				Return(testCase.ruleAddErr)
-			cleanup, err := wg.addRule4(rulePriority, firewallMark)
+			cleanup, err := wg.addRule(rulePriority, firewallMark, family)
 			if testCase.err != nil {
 				require.Error(t, err)
 				assert.Equal(t, testCase.err.Error(), err.Error())

--- a/internal/wireguard/rule_test.go
+++ b/internal/wireguard/rule_test.go
@@ -83,7 +83,7 @@ func Test_Wireguard_addRule(t *testing.T) {
 
 			netLinker.EXPECT().RuleAdd(testCase.expectedRule).
 				Return(testCase.ruleAddErr)
-			cleanup, err := wg.addRule(rulePriority, firewallMark)
+			cleanup, err := wg.addRule4(rulePriority, firewallMark)
 			if testCase.err != nil {
 				require.Error(t, err)
 				assert.Equal(t, testCase.err.Error(), err.Error())

--- a/internal/wireguard/run.go
+++ b/internal/wireguard/run.go
@@ -116,7 +116,14 @@ func (w *Wireguard) Run(ctx context.Context, waitError chan<- error, ready chan<
 		waitError <- fmt.Errorf("%w: %s", ErrRuleAdd, err)
 		return
 	}
+	ruleCleanup6, err := w.addRule6(
+		w.settings.RulePriority, w.settings.FirewallMark)
+	if err != nil {
+		waitError <- fmt.Errorf("%w: %s", ErrRuleAdd, err)
+		return
+	}
 	closers.add("removing rule", stepOne, ruleCleanup)
+	closers.add("removing rule", stepOne, ruleCleanup6)
 
 	w.logger.Info("Wireguard is up")
 	ready <- struct{}{}

--- a/internal/wireguard/run.go
+++ b/internal/wireguard/run.go
@@ -114,7 +114,7 @@ func (w *Wireguard) Run(ctx context.Context, waitError chan<- error, ready chan<
 			waitError <- fmt.Errorf("%w: %s", ErrRuleAdd, err)
 			return
 		}
-		closers.add("removing rule", stepOne, ruleCleanup6)
+		closers.add("removing IPv6 rule", stepOne, ruleCleanup6)
 	}
 
 	ruleCleanup, err := w.addRule4(
@@ -124,7 +124,7 @@ func (w *Wireguard) Run(ctx context.Context, waitError chan<- error, ready chan<
 		return
 	}
 
-	closers.add("removing rule", stepOne, ruleCleanup)
+	closers.add("removing IPv4 rule", stepOne, ruleCleanup)
 	w.logger.Info("Wireguard is up")
 	ready <- struct{}{}
 

--- a/internal/wireguard/run.go
+++ b/internal/wireguard/run.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/qdm12/gluetun/internal/netlink"
+	"golang.org/x/sys/unix"
 	"golang.zx2c4.com/wireguard/conn"
 	"golang.zx2c4.com/wireguard/device"
 	"golang.zx2c4.com/wireguard/ipc"
@@ -102,8 +103,8 @@ func (w *Wireguard) Run(ctx context.Context, waitError chan<- error, ready chan<
 		}
 	}
 
-	ruleCleanup, err := w.addRule4(
-		w.settings.RulePriority, w.settings.FirewallMark)
+	ruleCleanup, err := w.addRule(w.settings.RulePriority,
+		w.settings.FirewallMark, unix.AF_INET)
 	if err != nil {
 		waitError <- fmt.Errorf("adding IPv4 rule: %w", err)
 		return
@@ -130,8 +131,9 @@ func (w *Wireguard) setupIPv6(link netlink.Link, closers *closers) (err error) {
 		return fmt.Errorf("%w: %s", ErrRouteAdd, err)
 	}
 
-	ruleCleanup6, ruleErr := w.addRule6(
-		w.settings.RulePriority, w.settings.FirewallMark)
+	ruleCleanup6, ruleErr := w.addRule(
+		w.settings.RulePriority, w.settings.FirewallMark,
+		unix.AF_INET6)
 	if ruleErr != nil {
 		return fmt.Errorf("adding IPv6 rule: %w", err)
 	}

--- a/internal/wireguard/run.go
+++ b/internal/wireguard/run.go
@@ -29,7 +29,6 @@ var (
 	ErrDeviceInfo        = errors.New("cannot get wireguard device information")
 	ErrIfaceUp           = errors.New("cannot set the interface to UP")
 	ErrRouteAdd          = errors.New("cannot add route for interface")
-	ErrRuleAdd           = errors.New("cannot add rule for interface")
 	ErrDeviceWaited      = errors.New("device waited for")
 )
 
@@ -106,7 +105,7 @@ func (w *Wireguard) Run(ctx context.Context, waitError chan<- error, ready chan<
 	ruleCleanup, err := w.addRule4(
 		w.settings.RulePriority, w.settings.FirewallMark)
 	if err != nil {
-		waitError <- fmt.Errorf("%w: %s", ErrRuleAdd, err)
+		waitError <- fmt.Errorf("adding IPv4 rule: %w", err)
 		return
 	}
 
@@ -134,7 +133,7 @@ func (w *Wireguard) setupIPv6(link netlink.Link, closers *closers) (err error) {
 	ruleCleanup6, ruleErr := w.addRule6(
 		w.settings.RulePriority, w.settings.FirewallMark)
 	if ruleErr != nil {
-		return fmt.Errorf("%w: %s", ErrRuleAdd, err)
+		return fmt.Errorf("adding IPv6 rule: %w", err)
 	}
 
 	closers.add("removing IPv6 rule", stepOne, ruleCleanup6)

--- a/internal/wireguard/run.go
+++ b/internal/wireguard/run.go
@@ -108,23 +108,23 @@ func (w *Wireguard) Run(ctx context.Context, waitError chan<- error, ready chan<
 				return
 			}
 		}
+		ruleCleanup6, ruleErr := w.addRule6(
+			w.settings.RulePriority, w.settings.FirewallMark)
+		if ruleErr != nil {
+			waitError <- fmt.Errorf("%w: %s", ErrRuleAdd, err)
+			return
+		}
+		closers.add("removing rule", stepOne, ruleCleanup6)
 	}
 
-	ruleCleanup, err := w.addRule(
+	ruleCleanup, err := w.addRule4(
 		w.settings.RulePriority, w.settings.FirewallMark)
 	if err != nil {
 		waitError <- fmt.Errorf("%w: %s", ErrRuleAdd, err)
 		return
 	}
-	ruleCleanup6, err := w.addRule6(
-		w.settings.RulePriority, w.settings.FirewallMark)
-	if err != nil {
-		waitError <- fmt.Errorf("%w: %s", ErrRuleAdd, err)
-		return
-	}
+
 	closers.add("removing rule", stepOne, ruleCleanup)
-	closers.add("removing rule", stepOne, ruleCleanup6)
-
 	w.logger.Info("Wireguard is up")
 	ready <- struct{}{}
 


### PR DESCRIPTION
Enable ipv6 connection to Wireguard VPN servers & tunneling for IPv6 addresses.

There's still things to be done such as:
  -  use IPv6 by default and fallback to IPv4 if not functioning.
  - check if IPv6 is enabled on host before attempting to contact an IPv6 server

Fixes #154 
Might help #594 