### PR TITLE
fix(privateinternetaccess): fix getting token for port forwarding

### DIFF
--- a/internal/provider/privateinternetaccess/portforward.go
+++ b/internal/provider/privateinternetaccess/portforward.go
@@ -257,7 +257,6 @@ func fetchToken(ctx context.Context, client *http.Client,
 		return "", replaceInErr(err, errSubstitutions)
 	}
 
-	request.PostForm = form
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	response, err := client.Do(request)

--- a/internal/provider/privateinternetaccess/portforward.go
+++ b/internal/provider/privateinternetaccess/portforward.go
@@ -244,16 +244,21 @@ func fetchToken(ctx context.Context, client *http.Client,
 		url.QueryEscape(password): "<password>",
 	}
 
+	form := url.Values{}
+	form.Add("username", username)
+	form.Add("password", password)
 	url := url.URL{
 		Scheme: "https",
-		User:   url.UserPassword(username, password),
-		Host:   "privateinternetaccess.com",
-		Path:   "/gtoken/generateToken",
+		Host:   "www.privateinternetaccess.com",
+		Path:   "/api/client/v2/token",
 	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), strings.NewReader(form.Encode()))
 	if err != nil {
 		return "", replaceInErr(err, errSubstitutions)
 	}
+
+	request.PostForm = form
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	response, err := client.Do(request)
 	if err != nil {


### PR DESCRIPTION
Connection to PIA using OpenVPN worked fine, but getting a token for the port forwarding service resulted in HTTP errors.
Looking at the [latest official shell script to get a token](https://github.com/pia-foss/manual-connections/blob/9b42ad934a9353fbefda7cbab2725f4f3b1850a3/get_token.sh#L72) it seems that the token URL and method have changed. This PR adjusts gluetun to match.

Note: this is my first time writing/using Go.