### PR TITLE
updating fastestvpn servers

### DIFF
--- a/internal/provider/fastestvpn/updater/servers.go
+++ b/internal/provider/fastestvpn/updater/servers.go
@@ -13,7 +13,7 @@ import (
 
 func (u *Updater) FetchServers(ctx context.Context, minServers int) (
 	servers []models.Server, err error) {
-	const url = "https://support.fastestvpn.com/download/openvpn-tcp-udp-config-files"
+	const url = "http://support.fastestvpn.com/download/fastestvpn_ovpn"
 	contents, err := u.unzipper.FetchAndExtract(ctx, url)
 	if err != nil {
 		return nil, err

--- a/internal/provider/fastestvpn/updater/servers.go
+++ b/internal/provider/fastestvpn/updater/servers.go
@@ -13,7 +13,7 @@ import (
 
 func (u *Updater) FetchServers(ctx context.Context, minServers int) (
 	servers []models.Server, err error) {
-	const url = "http://support.fastestvpn.com/download/fastestvpn_ovpn"
+	const url = "https://support.fastestvpn.com/download/fastestvpn_ovpn"
 	contents, err := u.unzipper.FetchAndExtract(ctx, url)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I hope this will update fastestvpn servers in servers.json and config files. right now i am not able to use fastestvpn with gluetun.

Updater throws below error. I realized the url is not live anymore. i got the working url from fastestvpn support.

<img width="968" alt="image" src="https://user-images.githubusercontent.com/12549485/204872740-86d7b153-258b-4c4a-b39b-dea787a3d171.png">
