### PR TITLE
feat(settings): load wireguard inidivual fields as secret files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,10 +95,13 @@ ENV VPN_SERVICE_PROVIDER=pia \
     # Wireguard
     WIREGUARD_CONF_SECRETFILE=/run/secrets/wg0.conf \
     WIREGUARD_PRIVATE_KEY= \
+    WIREGUARD_PRIVATE_KEY_SECRETFILE=/run/secrets/wireguard_private_key \
     WIREGUARD_PRESHARED_KEY= \
+    WIREGUARD_PRESHARED_KEY_SECRETFILE=/run/secrets/wireguard_preshared_key \
     WIREGUARD_PUBLIC_KEY= \
     WIREGUARD_ALLOWED_IPS= \
     WIREGUARD_ADDRESSES= \
+    WIREGUARD_ADDRESSES_SECRETFILE=/run/secrets/wireguard_addresses \
     WIREGUARD_MTU=1400 \
     WIREGUARD_IMPLEMENTATION=auto \
     # VPN server filtering

--- a/internal/configuration/sources/secrets/helpers.go
+++ b/internal/configuration/sources/secrets/helpers.go
@@ -2,6 +2,8 @@ package secrets
 
 import (
 	"fmt"
+	"net/netip"
+	"strings"
 
 	"github.com/qdm12/gluetun/internal/configuration/sources/files"
 	"github.com/qdm12/gluetun/internal/openvpn/extract"
@@ -34,4 +36,23 @@ func (s *Source) readPEMSecretFile(secretPathEnvKey, defaultSecretPath string) (
 	}
 
 	return &base64Data, nil
+}
+
+func parseAddresses(addressesCSV string) (addresses []netip.Prefix, err error) {
+	if addressesCSV == "" {
+		return nil, nil
+	}
+
+	addressStrings := strings.Split(addressesCSV, ",")
+	addresses = make([]netip.Prefix, len(addressStrings))
+	for i, addressString := range addressStrings {
+		addressString = strings.TrimSpace(addressString)
+		addresses[i], err = netip.ParsePrefix(addressString)
+		if err != nil {
+			return nil, fmt.Errorf("parsing address %d of %d: %w",
+				i+1, len(addressStrings), err)
+		}
+	}
+
+	return addresses, nil
 }

--- a/internal/configuration/sources/secrets/vpn.go
+++ b/internal/configuration/sources/secrets/vpn.go
@@ -12,5 +12,10 @@ func (s *Source) readVPN() (vpn settings.VPN, err error) {
 		return vpn, fmt.Errorf("reading OpenVPN settings: %w", err)
 	}
 
+	vpn.Wireguard, err = s.readWireguard()
+	if err != nil {
+		return vpn, fmt.Errorf("reading Wireguard settings: %w", err)
+	}
+
 	return vpn, nil
 }

--- a/internal/configuration/sources/secrets/wireguard.go
+++ b/internal/configuration/sources/secrets/wireguard.go
@@ -15,7 +15,38 @@ func (s *Source) readWireguard() (settings settings.Wireguard, err error) {
 	if err != nil {
 		return settings, fmt.Errorf("reading Wireguard conf secret file: %w", err)
 	} else if wireguardConf != nil {
+		// Wireguard ini config file takes precedence over individual secrets
 		return files.ParseWireguardConf([]byte(*wireguardConf))
 	}
+
+	settings.PrivateKey, err = s.readSecretFileAsStringPtr(
+		"WIREGUARD_PRIVATE_KEY_SECRETFILE",
+		"/run/secrets/wireguard_private_key",
+	)
+	if err != nil {
+		return settings, fmt.Errorf("reading private key file: %w", err)
+	}
+
+	settings.PreSharedKey, err = s.readSecretFileAsStringPtr(
+		"WIREGUARD_PRESHARED_KEY_SECRETFILE",
+		"/run/secrets/wireguard_preshared_key",
+	)
+	if err != nil {
+		return settings, fmt.Errorf("reading preshared key file: %w", err)
+	}
+
+	wireguardAddressesCSV, err := s.readSecretFileAsStringPtr(
+		"WIREGUARD_ADDRESSES_SECRETFILE",
+		"/run/secrets/wireguard_addresses",
+	)
+	if err != nil {
+		return settings, fmt.Errorf("reading addresses file: %w", err)
+	} else if wireguardAddressesCSV != nil {
+		settings.Addresses, err = parseAddresses(*wireguardAddressesCSV)
+		if err != nil {
+			return settings, fmt.Errorf("parsing addresses: %w", err)
+		}
+	}
+
 	return settings, nil
 }


### PR DESCRIPTION
Currently docker secrets aren't supported for wireguard environment variables, but should.