### PR TITLE
Add updater vars to docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ services:
       # - WIREGUARD_ADDRESSES=10.64.222.21/32
       # Timezone for accurate log times
       - TZ=
+      # Server list updater. See https://github.com/qdm12/gluetun/wiki/Updating-Servers#periodic-update
+      - UPDATER_PERIOD=
+      - UPDATER_VPN_SERVICE_PROVIDERS=
 ```
 
 🆕 Image also available as `ghcr.io/qdm12/gluetun`


### PR DESCRIPTION
I'm proposing the addition of `UPDATER_PERIOD` and `UPDATER_VPN_SERVICE_PROVIDERS` to the [docker-compose example](https://github.com/qdm12/gluetun#setup) in the README to prevent the issue described in the discussion linked below. This will help bring awareness to the static list of servers that are shipped with each release and prevent connection issues when the IPs in the user's selected region(s) have become stale and there's no clear indicator given to the users to direct them to updating their local servers.json file. Knowing that releases can happen daily or bi-annually and the updater is disabled by default, I feel this is probably a no-brainer to prevent others, especially new users, from running into the same issue.

https://github.com/qdm12/gluetun/discussions/1356#discussioncomment-4947210