### PR TITLE
Update httpproxy.go to fix error message

### DIFF
--- a/internal/configuration/sources/secrets/httpproxy.go
+++ b/internal/configuration/sources/secrets/httpproxy.go
@@ -20,7 +20,7 @@ func readHTTPProxy() (settings settings.HTTPProxy, err error) {
 		"/run/secrets/httpproxy_password",
 	)
 	if err != nil {
-		return settings, fmt.Errorf("reading OpenVPN password secret file: %w", err)
+		return settings, fmt.Errorf("reading HTTP proxy password secret file: %w", err)
 	}
 
 	return settings, nil


### PR DESCRIPTION
Error message reading secret file for http proxy password wrongly refer to openvpn instead of http proxy