### PR TITLE
Fix ProtonVPN port forwarding assigning port zero

### DIFF
--- a/internal/provider/protonvpn/portforward.go
+++ b/internal/provider/protonvpn/portforward.go
@@ -35,7 +35,6 @@ func (p *Provider) PortForward(ctx context.Context, _ *http.Client,
 	networkProtocols := []string{"udp", "tcp"}
 	const internalPort, externalPort = 0, 0
 	const lifetime = 60 * time.Second
-	var assignedExternalPort uint16
 	for _, networkProtocol := range networkProtocols {
 		_, assignedInternalPort, assignedExternalPort, assignedLiftetime, err :=
 			client.AddPortMapping(ctx, gateway, networkProtocol,
@@ -55,9 +54,10 @@ func (p *Provider) PortForward(ctx context.Context, _ *http.Client,
 				" from external port assigned %d",
 				assignedInternalPort, assignedExternalPort))
 		}
+
+		port = assignedExternalPort
 	}
 
-	port = assignedExternalPort
 	return port, nil
 }
 


### PR DESCRIPTION
This fixes an issue in #1543 where the returned port will always be zero.

Built this locally and made sure the port was now correctly assigned:
```
gluetun-vpn_gateway-1  | 2023-06-01T20:23:34-07:00 INFO [port forwarding] port forwarded is 42757
gluetun-vpn_gateway-1  | 2023-06-01T20:23:34-07:00 INFO [firewall] setting allowed input port 42757 through interface tun0...
gluetun-vpn_gateway-1  | 2023-06-01T20:23:34-07:00 INFO [port forwarding] writing port file /tmp/gluetun/forwarded_port
```

I also used netcat to make sure both UDP and TCP was properly forwarded.