### PR TITLE
Category filtering for NordVPN

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ issues:
         - goerr113
         - containedctx
         - goconst
+        - maintidx
     - path: "internal\\/server\\/.+\\.go"
       linters:
         - dupl

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,7 @@ ENV VPN_SERVICE_PROVIDER=pia \
     SERVER_COUNTRIES= \
     SERVER_CITIES= \
     SERVER_HOSTNAMES= \
+    SERVER_CATEGORIES= \
     # # Mullvad only:
     ISP= \
     OWNED_ONLY=no \

--- a/internal/configuration/settings/errors.go
+++ b/internal/configuration/settings/errors.go
@@ -5,6 +5,7 @@ import "errors"
 var (
 	ErrCityNotValid                    = errors.New("the city specified is not valid")
 	ErrControlServerPrivilegedPort     = errors.New("cannot use privileged port without running as root")
+	ErrCategoryNotValid                = errors.New("the category specified is not valid")
 	ErrCountryNotValid                 = errors.New("the country specified is not valid")
 	ErrFilepathMissing                 = errors.New("filepath is missing")
 	ErrFirewallZeroPort                = errors.New("cannot have a zero port")

--- a/internal/configuration/settings/serverselection.go
+++ b/internal/configuration/settings/serverselection.go
@@ -27,8 +27,10 @@ type ServerSelection struct { //nolint:maligned
 	// state, and can be set to the unspecified address to indicate
 	// there is not target IP address to use.
 	TargetIP netip.Addr `json:"target_ip"`
-	// Counties is the list of countries to filter VPN servers with.
+	// Countries is the list of countries to filter VPN servers with.
 	Countries []string `json:"countries"`
+	// Categories is the list of categories to filter VPN servers with.
+	Categories []string `json:"categories"`
 	// Regions is the list of regions to filter VPN servers with.
 	Regions []string `json:"regions"`
 	// Cities is the list of cities to filter VPN servers with.
@@ -224,6 +226,11 @@ func validateServerFilters(settings ServerSelection, filterChoices models.Filter
 		return fmt.Errorf("%w: %w", ErrNameNotValid, err)
 	}
 
+	err = validate.AreAllOneOfCaseInsensitive(settings.Categories, filterChoices.Categories)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrCategoryNotValid, err)
+	}
+
 	return nil
 }
 
@@ -232,6 +239,7 @@ func (ss *ServerSelection) copy() (copied ServerSelection) {
 		VPN:             ss.VPN,
 		TargetIP:        ss.TargetIP,
 		Countries:       gosettings.CopySlice(ss.Countries),
+		Categories:      gosettings.CopySlice(ss.Categories),
 		Regions:         gosettings.CopySlice(ss.Regions),
 		Cities:          gosettings.CopySlice(ss.Cities),
 		ISPs:            gosettings.CopySlice(ss.ISPs),
@@ -253,6 +261,7 @@ func (ss *ServerSelection) mergeWith(other ServerSelection) {
 	ss.VPN = gosettings.MergeWithString(ss.VPN, other.VPN)
 	ss.TargetIP = gosettings.MergeWithValidator(ss.TargetIP, other.TargetIP)
 	ss.Countries = gosettings.MergeWithSlice(ss.Countries, other.Countries)
+	ss.Categories = gosettings.MergeWithSlice(ss.Categories, other.Categories)
 	ss.Regions = gosettings.MergeWithSlice(ss.Regions, other.Regions)
 	ss.Cities = gosettings.MergeWithSlice(ss.Cities, other.Cities)
 	ss.ISPs = gosettings.MergeWithSlice(ss.ISPs, other.ISPs)
@@ -274,6 +283,7 @@ func (ss *ServerSelection) overrideWith(other ServerSelection) {
 	ss.VPN = gosettings.OverrideWithString(ss.VPN, other.VPN)
 	ss.TargetIP = gosettings.OverrideWithValidator(ss.TargetIP, other.TargetIP)
 	ss.Countries = gosettings.OverrideWithSlice(ss.Countries, other.Countries)
+	ss.Categories = gosettings.OverrideWithSlice(ss.Categories, other.Categories)
 	ss.Regions = gosettings.OverrideWithSlice(ss.Regions, other.Regions)
 	ss.Cities = gosettings.OverrideWithSlice(ss.Cities, other.Cities)
 	ss.ISPs = gosettings.OverrideWithSlice(ss.ISPs, other.ISPs)
@@ -316,6 +326,10 @@ func (ss ServerSelection) toLinesNode() (node *gotree.Node) {
 
 	if len(ss.Countries) > 0 {
 		node.Appendf("Countries: %s", strings.Join(ss.Countries, ", "))
+	}
+
+	if len(ss.Categories) > 0 {
+		node.Appendf("Categories: %s", strings.Join(ss.Categories, ", "))
 	}
 
 	if len(ss.Regions) > 0 {

--- a/internal/configuration/settings/validation/servers.go
+++ b/internal/configuration/settings/validation/servers.go
@@ -33,6 +33,28 @@ func ExtractCountries(servers []models.Server) (values []string) {
 	return values
 }
 
+func ExtractCategories(servers []models.Server) (values []string) {
+	seen := make(map[string]struct{}, len(servers))
+	values = make([]string, 0, len(servers))
+	for _, server := range servers {
+		categories := server.Categories
+		if len(categories) == 0 {
+			continue
+		}
+
+		for _, value := range categories {
+			_, alreadySeen := seen[value]
+			if alreadySeen {
+				continue
+			}
+			seen[value] = struct{}{}
+
+			values = sortedInsert(values, value)
+		}
+	}
+	return values
+}
+
 func ExtractRegions(servers []models.Server) (values []string) {
 	seen := make(map[string]struct{}, len(servers))
 	values = make([]string, 0, len(servers))

--- a/internal/configuration/sources/env/serverselection.go
+++ b/internal/configuration/sources/env/serverselection.go
@@ -33,6 +33,7 @@ func (s *Source) readServerSelection(vpnProvider, vpnType string) (
 	ss.Hostnames = s.env.CSV("SERVER_HOSTNAMES", env.RetroKeys("SERVER_HOSTNAME"))
 	ss.Names = s.env.CSV("SERVER_NAMES", env.RetroKeys("SERVER_NAME"))
 	ss.Numbers, err = s.env.CSVUint16("SERVER_NUMBER")
+	ss.Categories = s.env.CSV("SERVER_CATEGORIES")
 	if err != nil {
 		return ss, err
 	}

--- a/internal/models/filters.go
+++ b/internal/models/filters.go
@@ -1,10 +1,11 @@
 package models
 
 type FilterChoices struct {
-	Countries []string
-	Regions   []string
-	Cities    []string
-	ISPs      []string
-	Names     []string
-	Hostnames []string
+	Countries  []string
+	Regions    []string
+	Cities     []string
+	Categories []string
+	ISPs       []string
+	Names      []string
+	Hostnames  []string
 }

--- a/internal/models/markdown.go
+++ b/internal/models/markdown.go
@@ -23,6 +23,7 @@ func markdownTableHeading(legendFields ...string) (markdown string) {
 const (
 	cityHeader        = "City"
 	countryHeader     = "Country"
+	categoriesHeader  = "Categories"
 	freeHeader        = "Free"
 	hostnameHeader    = "Hostname"
 	ispHeader         = "ISP"
@@ -51,6 +52,8 @@ func (s *Server) ToMarkdown(headers ...string) (markdown string) {
 			fields[i] = s.City
 		case countryHeader:
 			fields[i] = s.Country
+		case categoriesHeader:
+			fields[i] = strings.Join(s.Categories, ", ")
 		case freeHeader:
 			fields[i] = boolToMarkdown(s.Free)
 		case hostnameHeader:
@@ -120,7 +123,7 @@ func getMarkdownHeaders(vpnProvider string) (headers []string) {
 	case providers.Mullvad:
 		return []string{countryHeader, cityHeader, ispHeader, ownedHeader, hostnameHeader, vpnHeader}
 	case providers.Nordvpn:
-		return []string{countryHeader, regionHeader, cityHeader, hostnameHeader}
+		return []string{countryHeader, regionHeader, cityHeader, hostnameHeader, categoriesHeader}
 	case providers.Perfectprivacy:
 		return []string{cityHeader, tcpHeader, udpHeader}
 	case providers.Privado:

--- a/internal/models/server.go
+++ b/internal/models/server.go
@@ -17,6 +17,7 @@ type Server struct {
 	Region      string       `json:"region,omitempty"`
 	City        string       `json:"city,omitempty"`
 	ISP         string       `json:"isp,omitempty"`
+	Categories  []string     `json:"categories,omitempty"`
 	Owned       bool         `json:"owned,omitempty"`
 	Number      uint16       `json:"number,omitempty"`
 	ServerName  string       `json:"server_name,omitempty"`

--- a/internal/provider/nordvpn/updater/models.go
+++ b/internal/provider/nordvpn/updater/models.go
@@ -139,6 +139,19 @@ func (s *serverData) hasVPNService(services map[uint32]serviceData) (ok bool) {
 	return false
 }
 
+// categories returns the list of categories for the server.
+func (s *serverData) categories(groups map[uint32]groupData) (categories []string) {
+	categories = make([]string, 0, len(s.GroupIDs))
+	for _, groupID := range s.GroupIDs {
+		data, ok := groups[groupID]
+		if !ok || data.Type.Identifier == "regions" {
+			continue
+		}
+		categories = append(categories, data.Title)
+	}
+	return categories
+}
+
 // ips returns the list of IP addresses for the server.
 func (s *serverData) ips() (ips []netip.Addr) {
 	ips = make([]netip.Addr, 0, len(s.IPs))

--- a/internal/provider/nordvpn/updater/servers.go
+++ b/internal/provider/nordvpn/updater/servers.go
@@ -78,11 +78,12 @@ func extractServers(jsonServer serverData, groups map[uint32]groupData,
 	}
 
 	server := models.Server{
-		Country:  location.Country.Name,
-		Region:   jsonServer.region(groups),
-		City:     location.Country.City.Name,
-		Hostname: jsonServer.Hostname,
-		IPs:      jsonServer.ips(),
+		Country:    location.Country.Name,
+		Region:     jsonServer.region(groups),
+		City:       location.Country.City.Name,
+		Categories: jsonServer.categories(groups),
+		Hostname:   jsonServer.Hostname,
+		IPs:        jsonServer.ips(),
 	}
 
 	number, err := parseServerName(jsonServer.Name)

--- a/internal/provider/utils/filtering.go
+++ b/internal/provider/utils/filtering.go
@@ -61,6 +61,10 @@ func filterServer(server models.Server,
 		return true
 	}
 
+	if filterAnyByPossibilities(server.Categories, selection.Categories) {
+		return true
+	}
+
 	if filterByPossibilities(server.Region, selection.Regions) {
 		return true
 	}
@@ -99,5 +103,19 @@ func filterByPossibilities[T string | uint16](value T, possibilities []T) (filte
 			return false
 		}
 	}
+	return true
+}
+
+func filterAnyByPossibilities(values, possibilities []string) (filtered bool) {
+	if len(possibilities) == 0 {
+		return false
+	}
+
+	for _, value := range values {
+		if !filterByPossibilities(value, possibilities) {
+			return false // found a valid value
+		}
+	}
+
 	return true
 }

--- a/internal/provider/utils/filtering_test.go
+++ b/internal/provider/utils/filtering_test.go
@@ -179,6 +179,19 @@ func Test_FilterServers(t *testing.T) {
 				{City: "b", VPN: vpn.OpenVPN, UDP: true},
 			},
 		},
+		"filter by category": {
+			selection: settings.ServerSelection{
+				Categories: []string{"legacy_p2p"},
+			}.WithDefaults(providers.Nordvpn),
+			servers: []models.Server{
+				{Categories: []string{"legacy_p2p"}, VPN: vpn.OpenVPN, UDP: true},
+				{Categories: []string{"legacy_standard"}, VPN: vpn.OpenVPN, UDP: true},
+				{VPN: vpn.OpenVPN, UDP: true},
+			},
+			filtered: []models.Server{
+				{Categories: []string{"legacy_p2p"}, VPN: vpn.OpenVPN, UDP: true},
+			},
+		},
 		"filter by ISP": {
 			selection: settings.ServerSelection{
 				ISPs: []string{"b"},

--- a/internal/storage/choices.go
+++ b/internal/storage/choices.go
@@ -17,11 +17,12 @@ func (s *Storage) GetFilterChoices(provider string) models.FilterChoices {
 	serversObject := s.getMergedServersObject(provider)
 	servers := serversObject.Servers
 	return models.FilterChoices{
-		Countries: validation.ExtractCountries(servers),
-		Regions:   validation.ExtractRegions(servers),
-		Cities:    validation.ExtractCities(servers),
-		ISPs:      validation.ExtractISPs(servers),
-		Names:     validation.ExtractServerNames(servers),
-		Hostnames: validation.ExtractHostnames(servers),
+		Countries:  validation.ExtractCountries(servers),
+		Categories: validation.ExtractCategories(servers),
+		Regions:    validation.ExtractRegions(servers),
+		Cities:     validation.ExtractCities(servers),
+		ISPs:       validation.ExtractISPs(servers),
+		Names:      validation.ExtractServerNames(servers),
+		Hostnames:  validation.ExtractHostnames(servers),
 	}
 }

--- a/internal/storage/filter.go
+++ b/internal/storage/filter.go
@@ -82,6 +82,10 @@ func filterServer(server models.Server,
 		return true
 	}
 
+	if filterAnyByPossibilities(server.Categories, selection.Categories) {
+		return true
+	}
+
 	if filterByPossibilities(server.Region, selection.Regions) {
 		return true
 	}
@@ -120,6 +124,20 @@ func filterByPossibilities[T string | uint16](value T, possibilities []T) (filte
 			return false
 		}
 	}
+	return true
+}
+
+func filterAnyByPossibilities(values, possibilities []string) (filtered bool) {
+	if len(possibilities) == 0 {
+		return false
+	}
+
+	for _, value := range values {
+		if !filterByPossibilities(value, possibilities) {
+			return false // found a valid value
+		}
+	}
+
 	return true
 }
 

--- a/internal/storage/formatting.go
+++ b/internal/storage/formatting.go
@@ -37,6 +37,16 @@ func noServerFoundError(selection settings.ServerSelection) (err error) {
 		messageParts = append(messageParts, part)
 	}
 
+	switch len(selection.Categories) {
+	case 0:
+	case 1:
+		part := "category " + selection.Categories[0]
+		messageParts = append(messageParts, part)
+	default:
+		part := "categories " + commaJoin(selection.Categories)
+		messageParts = append(messageParts, part)
+	}
+
 	switch len(selection.Regions) {
 	case 0:
 	case 1:


### PR DESCRIPTION
Aims to fix #1643 

I am _not_ a GO developer, please read this code carefully!

![image](https://github.com/qdm12/gluetun/assets/18214951/c7672e2c-becc-4dc0-a826-056a84160a0a)

![image](https://github.com/qdm12/gluetun/assets/18214951/99f3fcc0-1f6a-493a-a4f2-a072e588b2e8)

After talking to NordVPN support, as long as a server supports P2P, a P2P connection will be established once it's determined there is a need for it (IE seeing P2P traffic). There's no way of knowing if it has connected to the P2P server other than contacting support with the IP address or results from `curl https://ipleak.net/json/`. I did ask if there was a way of starting the connection and specifying P2P from the get-go to avoid any switching but they said there was no documentation on this.

I've also [seen online](https://www.reddit.com/r/nordvpn/comments/q6astb/comment/hgbawxq/) that this switch from standard to P2P can result in you being reconnected to a "better" server, but this could also introduce latency.

TL;DR Nord claims it "just works"

Also unsure on testing? I've added a single test case for the categories - please let me know if there's anything more I can do here.