### PR TITLE
Tweak handling of "tcp-client" config value

### DIFF
--- a/internal/openvpn/extract/extract.go
+++ b/internal/openvpn/extract/extract.go
@@ -81,7 +81,11 @@ func extractProto(line string) (protocol string, err error) {
 	}
 
 	switch fields[1] {
-	case "tcp", "tcp4", "tcp6", "tcp-client", "udp", "udp4", "udp6":
+	case "tcp-client":
+		// Special treatment for this config option, as we need it to become
+		// "tcp" later, for use in iptables commands.
+		return "tcp", nil
+	case "tcp", "tcp4", "tcp6", "udp", "udp4", "udp6":
 	default:
 		return "", fmt.Errorf("%w: %s", errProtocolNotSupported, fields[1])
 	}


### PR DESCRIPTION
Make it the same case as "tcp", so the protocol name can be used without changes in iptables commands.

This deals with the side-effect mentioned in https://github.com/qdm12/gluetun/issues/1967.