### PR TITLE
feat: add PORT_FORWARD_ONLY env to filter for servers with port forwarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,6 +134,8 @@ ENV VPN_SERVICE_PROVIDER=pia \
     MULTIHOP_ONLY= \
     # # VPN Secure only:
     PREMIUM_ONLY= \
+    # # PIA only:
+    PORT_FORWARD_ONLY= \
     # Firewall
     FIREWALL=on \
     FIREWALL_VPN_INPUT_PORTS= \

--- a/internal/configuration/sources/env/serverselection.go
+++ b/internal/configuration/sources/env/serverselection.go
@@ -67,6 +67,12 @@ func (s *Source) readServerSelection(vpnProvider, vpnType string) (
 		return ss, err
 	}
 
+	// PIA only
+	ss.PortForwardOnly, err = s.env.BoolPtr("PORT_FORWARD_ONLY")
+	if err != nil {
+		return ss, err
+	}
+
 	ss.OpenVPN, err = s.readOpenVPNSelection()
 	if err != nil {
 		return ss, err

--- a/internal/provider/utils/filtering.go
+++ b/internal/provider/utils/filtering.go
@@ -53,6 +53,10 @@ func filterServer(server models.Server,
 		return true
 	}
 
+	if *selection.PortForwardOnly && !server.PortForward {
+		return true
+	}
+
 	if filterByPossibilities(server.Country, selection.Countries) {
 		return true
 	}

--- a/internal/provider/utils/filtering_test.go
+++ b/internal/provider/utils/filtering_test.go
@@ -127,6 +127,19 @@ func Test_FilterServers(t *testing.T) {
 				{Owned: true, VPN: vpn.OpenVPN, UDP: true},
 			},
 		},
+		"filter by port forwarding only": {
+			selection: settings.ServerSelection{
+				PortForwardOnly: boolPtr(true),
+			}.WithDefaults(providers.PrivateInternetAccess),
+			servers: []models.Server{
+				{PortForward: false, VPN: vpn.OpenVPN, UDP: true},
+				{PortForward: true, VPN: vpn.OpenVPN, UDP: true},
+				{PortForward: false, VPN: vpn.OpenVPN, UDP: true},
+			},
+			filtered: []models.Server{
+				{PortForward: true, VPN: vpn.OpenVPN, UDP: true},
+			},
+		},
 		"filter by country": {
 			selection: settings.ServerSelection{
 				Countries: []string{"b"},

--- a/internal/storage/filter.go
+++ b/internal/storage/filter.go
@@ -74,6 +74,10 @@ func filterServer(server models.Server,
 		return true
 	}
 
+	if *selection.PortForwardOnly && !server.PortForward {
+		return true
+	}
+
 	if filterByPossibilities(server.Country, selection.Countries) {
 		return true
 	}


### PR DESCRIPTION
Was in TODO per comment in code, so I took freedom to implement this. It adds another env PORT_FORWARD_ONLY which will filter for servers supporting port forwarding. This works only for PIA, I presume, so I locked this to only PIA support. Cases like #2048 could be mitigated with this PR merged and this settings on.