### PR TITLE
fix: STREAM_ONLY env should set StreamOnly flag for server selection

### DIFF
--- a/internal/configuration/sources/env/serverselection.go
+++ b/internal/configuration/sources/env/serverselection.go
@@ -55,14 +55,14 @@ func (s *Source) readServerSelection(vpnProvider, vpnType string) (
 		return ss, err
 	}
 
-	// VPNUnlimited only
+	// Surfshark only
 	ss.MultiHopOnly, err = s.env.BoolPtr("MULTIHOP_ONLY")
 	if err != nil {
 		return ss, err
 	}
 
 	// VPNUnlimited only
-	ss.MultiHopOnly, err = s.env.BoolPtr("STREAM_ONLY")
+	ss.StreamOnly, err = s.env.BoolPtr("STREAM_ONLY")
 	if err != nil {
 		return ss, err
 	}


### PR DESCRIPTION
Found a typo while fixing #2070, seems like `STREAM_ONLY` env set `MultihopOnly` flag while it should set `StreamOnly`.