### PR TITLE
fix: crash in custom wireguard connection with no server names

### DIFF
--- a/internal/provider/custom/connection.go
+++ b/internal/provider/custom/connection.go
@@ -57,7 +57,6 @@ func getWireguardConnection(selection settings.ServerSelection) (
 		Port:       *selection.Wireguard.EndpointPort,
 		Protocol:   constants.UDP,
 		PubKey:     selection.Wireguard.PublicKey,
-		ServerName: selection.Names[0],
 	}
 	if len(selection.Names) > 0 {
 		// Set the server name for PIA port forwarding code used


### PR DESCRIPTION
Currently accessing `selection.Names[0]` can cause an index out of bounds panic if the user did not set any server names in their config.

This change deletes the line that would cause the crash, while leaving the existing conditional set in the [line below](https://github.com/qdm12/gluetun/compare/master...junr03:gluetun:fix-crash?expand=1#diff-3cd37d747c18d398d306f661c1ff4639931b86ca948354ced26d5e1b74b7190fL62).