### PR TITLE
feat(settings): add storage filepath settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,6 +206,8 @@ ENV VPN_SERVICE_PROVIDER=pia \
     PUBLICIP_PERIOD=12h \
     PUBLICIP_API=ipinfo \
     PUBLICIP_API_TOKEN= \
+    # Storage
+    STORAGE_FILEPATH=/gluetun/servers.json \
     # Pprof
     PPROF_ENABLED=no \
     PPROF_BLOCK_PROFILE_RATE=0 \

--- a/cmd/gluetun/main.go
+++ b/cmd/gluetun/main.go
@@ -239,7 +239,7 @@ func _main(ctx context.Context, buildInfo models.BuildInformation,
 
 	// TODO run this in a loop or in openvpn to reload from file without restarting
 	storageLogger := logger.New(log.SetComponent("storage"))
-	storage, err := storage.New(storageLogger, constants.ServersData)
+	storage, err := storage.New(storageLogger, *allSettings.Storage.Filepath)
 	if err != nil {
 		return err
 	}

--- a/internal/configuration/settings/provider.go
+++ b/internal/configuration/settings/provider.go
@@ -25,7 +25,7 @@ type Provider struct {
 }
 
 // TODO v4 remove pointer for receiver (because of Surfshark).
-func (p *Provider) validate(vpnType string, storage Storage, warner Warner) (err error) {
+func (p *Provider) validate(vpnType string, filterChoicesGetter FilterChoicesGetter, warner Warner) (err error) {
 	// Validate Name
 	var validNames []string
 	if vpnType == vpn.OpenVPN {
@@ -48,7 +48,7 @@ func (p *Provider) validate(vpnType string, storage Storage, warner Warner) (err
 		return fmt.Errorf("%w for Wireguard: %w", ErrVPNProviderNameNotValid, err)
 	}
 
-	err = p.ServerSelection.validate(p.Name, storage, warner)
+	err = p.ServerSelection.validate(p.Name, filterChoicesGetter, warner)
 	if err != nil {
 		return fmt.Errorf("server selection: %w", err)
 	}

--- a/internal/configuration/settings/serverselection.go
+++ b/internal/configuration/settings/serverselection.go
@@ -91,14 +91,14 @@ var (
 )
 
 func (ss *ServerSelection) validate(vpnServiceProvider string,
-	storage Storage, warner Warner) (err error) {
+	filterChoicesGetter FilterChoicesGetter, warner Warner) (err error) {
 	switch ss.VPN {
 	case vpn.OpenVPN, vpn.Wireguard:
 	default:
 		return fmt.Errorf("%w: %s", ErrVPNTypeNotValid, ss.VPN)
 	}
 
-	filterChoices, err := getLocationFilterChoices(vpnServiceProvider, ss, storage, warner)
+	filterChoices, err := getLocationFilterChoices(vpnServiceProvider, ss, filterChoicesGetter, warner)
 	if err != nil {
 		return err // already wrapped error
 	}
@@ -142,9 +142,9 @@ func (ss *ServerSelection) validate(vpnServiceProvider string,
 }
 
 func getLocationFilterChoices(vpnServiceProvider string,
-	ss *ServerSelection, storage Storage, warner Warner) (
+	ss *ServerSelection, filterChoicesGetter FilterChoicesGetter, warner Warner) (
 	filterChoices models.FilterChoices, err error) {
-	filterChoices = storage.GetFilterChoices(vpnServiceProvider)
+	filterChoices = filterChoicesGetter.GetFilterChoices(vpnServiceProvider)
 
 	if vpnServiceProvider == providers.Surfshark {
 		// // Retro compatibility

--- a/internal/configuration/settings/settings.go
+++ b/internal/configuration/settings/settings.go
@@ -22,6 +22,7 @@ type Settings struct {
 	Log           Log
 	PublicIP      PublicIP
 	Shadowsocks   Shadowsocks
+	Storage       StorageSettings
 	System        System
 	Updater       Updater
 	Version       Version
@@ -47,6 +48,7 @@ func (s *Settings) Validate(storage Storage, ipv6Supported bool,
 		"log":             s.Log.validate,
 		"public ip check": s.PublicIP.validate,
 		"shadowsocks":     s.Shadowsocks.validate,
+		"storage":         s.Storage.validate,
 		"system":          s.System.validate,
 		"updater":         s.Updater.Validate,
 		"version":         s.Version.validate,
@@ -76,6 +78,7 @@ func (s *Settings) copy() (copied Settings) {
 		Log:           s.Log.copy(),
 		PublicIP:      s.PublicIP.copy(),
 		Shadowsocks:   s.Shadowsocks.copy(),
+		Storage:       s.Storage.copy(),
 		System:        s.System.copy(),
 		Updater:       s.Updater.copy(),
 		Version:       s.Version.copy(),
@@ -95,6 +98,7 @@ func (s *Settings) OverrideWith(other Settings,
 	patchedSettings.Log.overrideWith(other.Log)
 	patchedSettings.PublicIP.overrideWith(other.PublicIP)
 	patchedSettings.Shadowsocks.overrideWith(other.Shadowsocks)
+	patchedSettings.Storage.overrideWith(other.Storage)
 	patchedSettings.System.overrideWith(other.System)
 	patchedSettings.Updater.overrideWith(other.Updater)
 	patchedSettings.Version.overrideWith(other.Version)
@@ -117,6 +121,7 @@ func (s *Settings) SetDefaults() {
 	s.Log.setDefaults()
 	s.PublicIP.setDefaults()
 	s.Shadowsocks.setDefaults()
+	s.Storage.setDefaults()
 	s.System.setDefaults()
 	s.Version.setDefaults()
 	s.VPN.setDefaults()
@@ -139,6 +144,7 @@ func (s Settings) toLinesNode() (node *gotree.Node) {
 	node.AppendNode(s.Shadowsocks.toLinesNode())
 	node.AppendNode(s.HTTPProxy.toLinesNode())
 	node.AppendNode(s.ControlServer.toLinesNode())
+	node.AppendNode(s.Storage.toLinesNode())
 	node.AppendNode(s.System.toLinesNode())
 	node.AppendNode(s.PublicIP.toLinesNode())
 	node.AppendNode(s.Updater.toLinesNode())
@@ -188,6 +194,7 @@ func (s *Settings) Read(r *reader.Reader) (err error) {
 		"log":            s.Log.read,
 		"public ip":      s.PublicIP.read,
 		"shadowsocks":    s.Shadowsocks.read,
+		"storage":        s.Storage.read,
 		"system":         s.System.read,
 		"updater":        s.Updater.read,
 		"version":        s.Version.read,

--- a/internal/configuration/settings/settings.go
+++ b/internal/configuration/settings/settings.go
@@ -22,7 +22,7 @@ type Settings struct {
 	Log           Log
 	PublicIP      PublicIP
 	Shadowsocks   Shadowsocks
-	Storage       StorageSettings
+	Storage       Storage
 	System        System
 	Updater       Updater
 	Version       Version

--- a/internal/configuration/settings/storage.go
+++ b/internal/configuration/settings/storage.go
@@ -22,6 +22,7 @@ func (s Storage) validate() (err error) {
 			return fmt.Errorf("filepath is not valid: %w", err)
 		}
 	}
+	return nil
 }
 
 func (s *Storage) copy() (copied Storage) {

--- a/internal/configuration/settings/storage.go
+++ b/internal/configuration/settings/storage.go
@@ -1,7 +1,9 @@
 package settings
 
 import (
-	"github.com/qdm12/gluetun/internal/constants"
+	"fmt"
+	"path/filepath"
+
 	"github.com/qdm12/gosettings"
 	"github.com/qdm12/gosettings/reader"
 	"github.com/qdm12/gotree"
@@ -45,7 +47,7 @@ func (s StorageSettings) toLinesNode() (node *gotree.Node) {
 	if *s.Filepath == "" {
 		return gotree.New("Storage settings: disabled")
 	}
-	node = gotree.New("Storage settings:")		
+	node = gotree.New("Storage settings:")
 	node.Appendf("Filepath: %s", *s.Filepath)
 	return node
 }

--- a/internal/configuration/settings/storage.go
+++ b/internal/configuration/settings/storage.go
@@ -1,0 +1,50 @@
+package settings
+
+import (
+	"github.com/qdm12/gluetun/internal/constants"
+	"github.com/qdm12/gosettings"
+	"github.com/qdm12/gosettings/reader"
+	"github.com/qdm12/gotree"
+)
+
+// StorageSettings contains settings to configure the storage.
+type StorageSettings struct {
+	// Filepath is the path to the servers.json file. An empty string disables on-disk storage.
+	Filepath *string
+}
+
+func (s StorageSettings) validate() (err error) {
+	return nil
+}
+
+func (s *StorageSettings) copy() (copied StorageSettings) {
+	return StorageSettings{
+		Filepath: s.Filepath,
+	}
+}
+
+// overrideWith overrides fields of the receiver
+// settings object with any field set in the other
+// settings.
+func (s *StorageSettings) overrideWith(other StorageSettings) {
+	s.Filepath = gosettings.OverrideWithPointer(s.Filepath, other.Filepath)
+}
+
+func (s *StorageSettings) setDefaults() {
+	s.Filepath = gosettings.DefaultPointer(s.Filepath, constants.ServersData)
+}
+
+func (s StorageSettings) String() string {
+	return s.toLinesNode().String()
+}
+
+func (s StorageSettings) toLinesNode() (node *gotree.Node) {
+	node = gotree.New("Storage settings:")
+	node.Appendf("Filepath: %s", *s.Filepath)
+	return node
+}
+
+func (s *StorageSettings) read(r *reader.Reader) (err error) {
+	s.Filepath = r.Get("STORAGE_FILEPATH", reader.AcceptEmpty(true))
+	return nil
+}

--- a/internal/configuration/settings/storage.go
+++ b/internal/configuration/settings/storage.go
@@ -9,13 +9,13 @@ import (
 	"github.com/qdm12/gotree"
 )
 
-// StorageSettings contains settings to configure the storage.
-type StorageSettings struct {
+// Storage contains settings to configure the storage.
+type Storage struct {
 	// Filepath is the path to the servers.json file. An empty string disables on-disk storage.
 	Filepath *string
 }
 
-func (s StorageSettings) validate() (err error) {
+func (s Storage) validate() (err error) {
 	if *s.Filepath != "" { // optional
 		_, err := filepath.Abs(*s.Filepath)
 		if err != nil {
@@ -24,26 +24,26 @@ func (s StorageSettings) validate() (err error) {
 	}
 }
 
-func (s *StorageSettings) copy() (copied StorageSettings) {
-	return StorageSettings{
+func (s *Storage) copy() (copied Storage) {
+	return Storage{
 		Filepath: gosettings.CopyPointer(s.Filepath),
 	}
 }
 
-func (s *StorageSettings) overrideWith(other StorageSettings) {
+func (s *Storage) overrideWith(other Storage) {
 	s.Filepath = gosettings.OverrideWithPointer(s.Filepath, other.Filepath)
 }
 
-func (s *StorageSettings) setDefaults() {
+func (s *Storage) setDefaults() {
 	const defaultFilepath = "/gluetun/servers.json"
 	s.Filepath = gosettings.DefaultPointer(s.Filepath, defaultFilepath)
 }
 
-func (s StorageSettings) String() string {
+func (s Storage) String() string {
 	return s.toLinesNode().String()
 }
 
-func (s StorageSettings) toLinesNode() (node *gotree.Node) {
+func (s Storage) toLinesNode() (node *gotree.Node) {
 	if *s.Filepath == "" {
 		return gotree.New("Storage settings: disabled")
 	}
@@ -52,7 +52,7 @@ func (s StorageSettings) toLinesNode() (node *gotree.Node) {
 	return node
 }
 
-func (s *StorageSettings) read(r *reader.Reader) (err error) {
+func (s *Storage) read(r *reader.Reader) (err error) {
 	s.Filepath = r.Get("STORAGE_FILEPATH", reader.AcceptEmpty(true))
 	return nil
 }

--- a/internal/configuration/settings/vpn.go
+++ b/internal/configuration/settings/vpn.go
@@ -21,14 +21,14 @@ type VPN struct {
 }
 
 // TODO v4 remove pointer for receiver (because of Surfshark).
-func (v *VPN) Validate(storage Storage, ipv6Supported bool, warner Warner) (err error) {
+func (v *VPN) Validate(filterChoicesGetter FilterChoicesGetter, ipv6Supported bool, warner Warner) (err error) {
 	// Validate Type
 	validVPNTypes := []string{vpn.OpenVPN, vpn.Wireguard}
 	if err = validate.IsOneOf(v.Type, validVPNTypes...); err != nil {
 		return fmt.Errorf("%w: %w", ErrVPNTypeNotValid, err)
 	}
 
-	err = v.Provider.validate(v.Type, storage, warner)
+	err = v.Provider.validate(v.Type, filterChoicesGetter, warner)
 	if err != nil {
 		return fmt.Errorf("provider settings: %w", err)
 	}


### PR DESCRIPTION
This patch adds a new storage settings object with a single field to
control the storage filepath.

One use case is to set the filepath to the empy string, which will
disable reading and writing of the servers.json file. This is useful for
deployments that want to minimize I/O and want to set tight memory
limits (writing the servers.json spikes memory).

Fixes #2074