### PR TITLE
feat(config): allow invalid server filters

### DIFF
--- a/cmd/gluetun/main.go
+++ b/cmd/gluetun/main.go
@@ -249,7 +249,7 @@ func _main(ctx context.Context, buildInfo models.BuildInformation,
 		return fmt.Errorf("checking for IPv6 support: %w", err)
 	}
 
-	err = allSettings.Validate(storage, ipv6Supported)
+	err = allSettings.Validate(storage, ipv6Supported, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/openvpnconfig.go
+++ b/internal/cli/openvpnconfig.go
@@ -59,7 +59,7 @@ func (c *CLI) OpenvpnConfig(logger OpenvpnConfigLogger, reader *reader.Reader,
 		return fmt.Errorf("checking for IPv6 support: %w", err)
 	}
 
-	if err = allSettings.Validate(storage, ipv6Supported); err != nil {
+	if err = allSettings.Validate(storage, ipv6Supported, logger); err != nil {
 		return fmt.Errorf("validating settings: %w", err)
 	}
 

--- a/internal/configuration/settings/interfaces.go
+++ b/internal/configuration/settings/interfaces.go
@@ -1,0 +1,5 @@
+package settings
+
+type Warner interface {
+	Warn(message string)
+}

--- a/internal/configuration/settings/provider.go
+++ b/internal/configuration/settings/provider.go
@@ -25,7 +25,7 @@ type Provider struct {
 }
 
 // TODO v4 remove pointer for receiver (because of Surfshark).
-func (p *Provider) validate(vpnType string, storage Storage) (err error) {
+func (p *Provider) validate(vpnType string, storage Storage, warner Warner) (err error) {
 	// Validate Name
 	var validNames []string
 	if vpnType == vpn.OpenVPN {
@@ -48,7 +48,7 @@ func (p *Provider) validate(vpnType string, storage Storage) (err error) {
 		return fmt.Errorf("%w for Wireguard: %w", ErrVPNProviderNameNotValid, err)
 	}
 
-	err = p.ServerSelection.validate(p.Name, storage)
+	err = p.ServerSelection.validate(p.Name, storage, warner)
 	if err != nil {
 		return fmt.Errorf("server selection: %w", err)
 	}

--- a/internal/configuration/settings/settings.go
+++ b/internal/configuration/settings/settings.go
@@ -36,7 +36,8 @@ type Storage interface {
 // Validate validates all the settings and returns an error
 // if one of them is not valid.
 // TODO v4 remove pointer for receiver (because of Surfshark).
-func (s *Settings) Validate(storage Storage, ipv6Supported bool) (err error) {
+func (s *Settings) Validate(storage Storage, ipv6Supported bool,
+	warner Warner) (err error) {
 	nameToValidation := map[string]func() error{
 		"control server":  s.ControlServer.validate,
 		"dns":             s.DNS.validate,
@@ -51,7 +52,7 @@ func (s *Settings) Validate(storage Storage, ipv6Supported bool) (err error) {
 		"version":         s.Version.validate,
 		// Pprof validation done in pprof constructor
 		"VPN": func() error {
-			return s.VPN.Validate(storage, ipv6Supported)
+			return s.VPN.Validate(storage, ipv6Supported, warner)
 		},
 	}
 
@@ -84,7 +85,7 @@ func (s *Settings) copy() (copied Settings) {
 }
 
 func (s *Settings) OverrideWith(other Settings,
-	storage Storage, ipv6Supported bool) (err error) {
+	storage Storage, ipv6Supported bool, warner Warner) (err error) {
 	patchedSettings := s.copy()
 	patchedSettings.ControlServer.overrideWith(other.ControlServer)
 	patchedSettings.DNS.overrideWith(other.DNS)
@@ -99,7 +100,7 @@ func (s *Settings) OverrideWith(other Settings,
 	patchedSettings.Version.overrideWith(other.Version)
 	patchedSettings.VPN.OverrideWith(other.VPN)
 	patchedSettings.Pprof.OverrideWith(other.Pprof)
-	err = patchedSettings.Validate(storage, ipv6Supported)
+	err = patchedSettings.Validate(storage, ipv6Supported, warner)
 	if err != nil {
 		return err
 	}

--- a/internal/configuration/settings/vpn.go
+++ b/internal/configuration/settings/vpn.go
@@ -21,14 +21,14 @@ type VPN struct {
 }
 
 // TODO v4 remove pointer for receiver (because of Surfshark).
-func (v *VPN) Validate(storage Storage, ipv6Supported bool) (err error) {
+func (v *VPN) Validate(storage Storage, ipv6Supported bool, warner Warner) (err error) {
 	// Validate Type
 	validVPNTypes := []string{vpn.OpenVPN, vpn.Wireguard}
 	if err = validate.IsOneOf(v.Type, validVPNTypes...); err != nil {
 		return fmt.Errorf("%w: %w", ErrVPNTypeNotValid, err)
 	}
 
-	err = v.Provider.validate(v.Type, storage)
+	err = v.Provider.validate(v.Type, storage, warner)
 	if err != nil {
 		return fmt.Errorf("provider settings: %w", err)
 	}

--- a/internal/server/vpn.go
+++ b/internal/server/vpn.go
@@ -116,7 +116,7 @@ func (h *vpnHandler) patchSettings(w http.ResponseWriter, r *http.Request) {
 
 	updatedSettings := h.looper.GetSettings() // already copied
 	updatedSettings.OverrideWith(overrideSettings)
-	err = updatedSettings.Validate(h.storage, h.ipv6Supported)
+	err = updatedSettings.Validate(h.storage, h.ipv6Supported, h.warner)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return


### PR DESCRIPTION
- Disallow setting a server filter when there is no choice available
- Allow setting an invalid server filter when there is at least one choice available
- Log at warn level when an invalid server filter is set
- Fix #2337 