### PR TITLE
fix(pia): support port forwarding using Wireguard

### DIFF
--- a/internal/configuration/settings/serverselection.go
+++ b/internal/configuration/settings/serverselection.go
@@ -191,11 +191,19 @@ func validateServerFilters(settings ServerSelection, filterChoices models.Filter
 		return fmt.Errorf("%w: %w", ErrHostnameNotValid, err)
 	}
 
-	if vpnServiceProvider == providers.Custom && len(settings.Names) == 1 {
-		// Allow a single name to be specified for the custom provider in case
-		// the user wants to use VPN server side port forwarding with PIA
-		// which requires a server name for TLS verification.
-		filterChoices.Names = settings.Names
+	if vpnServiceProvider == providers.Custom {
+		switch len(settings.Names) {
+		case 0:
+		case 1:
+			// Allow a single name to be specified for the custom provider in case
+			// the user wants to use VPN server side port forwarding with PIA
+			// which requires a server name for TLS verification.
+			filterChoices.Names = settings.Names
+		default:
+			return fmt.Errorf("%w: %d names specified instead of "+
+				"0 or 1 for the custom provider",
+				ErrNameNotValid, len(settings.Names))
+		}
 	}
 	err = atLeastOneIsOneOfCaseInsensitive(settings.Names, filterChoices.Names, warner)
 	if err != nil {


### PR DESCRIPTION
- [x] Build API ip address using the first 2 bytes of the gateway IP and adding `128.1` to it
- [x] Check it works with Wireguard + custom provider
- [x] Check it works with OpenVPN. Otherwise add a field to specify which vpn protocol is in use and compute the gateway only for Wireguard
- [x] Update wiki
- Fix #2320 