### PR TITLE
feat(control server authentication): add basic http auth

### DIFF
--- a/internal/server/middlewares/auth/basic.go
+++ b/internal/server/middlewares/auth/basic.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"net/http"
+	"strings"
+)
+
+type basicAuthMethod struct {
+	userpasshash [32]byte
+}
+
+func newBasicAuthMethod(user string, pass string) *basicAuthMethod {
+	var sb strings.Builder
+
+	sb.WriteString(user)
+	sb.WriteString(pass)
+	var matchbytes = sha256.Sum256([]byte(sb.String()))
+	return &basicAuthMethod{
+		userpasshash: matchbytes,
+	}
+}
+
+// equal returns true if another auth checker is equal.
+// This is used to deduplicate checkers for a particular route.
+func (a *basicAuthMethod) equal(other authorizationChecker) bool {
+	otherBasicMethod, ok := other.(*basicAuthMethod)
+	if !ok {
+		return false
+	}
+	return a.userpasshash == otherBasicMethod.userpasshash
+}
+
+func (a *basicAuthMethod) isAuthorized(r *http.Request) bool {
+	authsuccess := false
+	var inpSb strings.Builder
+	// Get Inputs from http request
+	username, password, ok := r.BasicAuth()
+	if ok {
+		inpSb.WriteString(username)
+		inpSb.WriteString(password)
+		inputhash := sha256.Sum256([]byte(inpSb.String()))
+		authsuccess = (subtle.ConstantTimeCompare(a.userpasshash[:], inputhash[:]) == 1)
+	}
+	if authsuccess {
+		return true
+	}
+
+	return false
+}

--- a/internal/server/middlewares/auth/lookup.go
+++ b/internal/server/middlewares/auth/lookup.go
@@ -18,6 +18,8 @@ func settingsToLookupMap(settings Settings) (routeToRoles map[string][]internalR
 			checker = newNoneMethod()
 		case AuthAPIKey:
 			checker = newAPIKeyMethod(role.APIKey)
+		case AuthBasic:
+			checker = newBasicAuthMethod(role.Username, role.Password)
 		default:
 			return nil, fmt.Errorf("%w: %s", ErrMethodNotSupported, role.Auth)
 		}


### PR DESCRIPTION
  -  Add basic http auth to vpn/settings  & openvpn/settings routes.
  - Get username and password from environment variables.
  - Sets a default username and password.

Partly fixes #2238 

@qdm12 , please provide feedback.
Do we need a default username and password.
I have added basic auth only for the /settings route so that breakage with existing users are minimal.

Edit:
Original PR is updated to use the new auth middleware. Above points are no longer valid.
See #2238 , #2434 