### PR TITLE
fix(wireguard): add ivp6 rule

### DIFF
--- a/internal/wireguard/rule.go
+++ b/internal/wireguard/rule.go
@@ -2,6 +2,7 @@ package wireguard
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/qdm12/gluetun/internal/netlink"
 )
@@ -16,6 +17,10 @@ func (w *Wireguard) addRule(rulePriority int, firewallMark uint32,
 	rule.Table = int(firewallMark)
 	rule.Family = family
 	if err := w.netlink.RuleAdd(rule); err != nil {
+		if strings.HasSuffix(err.Error(), "file exists") {
+			w.logger.Info("if you are using Kubernetes, this may fix the error below: " +
+				"https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/kubernetes.md#adding-ipv6-rule--file-exists")
+		}
 		return nil, fmt.Errorf("adding %s: %w", rule, err)
 	}
 


### PR DESCRIPTION
Related to #2521 #2471 and #1991

Considers the `file exists` error as a success for adding an IP rule.

Run with image tag `:pr-2526`