### PR TITLE
fix(firewall): pass -n to iptables in path test

### DIFF
--- a/internal/firewall/support.go
+++ b/internal/firewall/support.go
@@ -92,7 +92,7 @@ func testIptablesPath(ctx context.Context, path string,
 	// Set policy as the existing policy so no mutation is done.
 	// This is an extra check for some buggy kernels where setting the policy
 	// does not work.
-	cmd = exec.CommandContext(ctx, path, "-L", "INPUT")
+	cmd = exec.CommandContext(ctx, path, "-nL", "INPUT")
 	output, err = runner.Run(cmd)
 	if err != nil {
 		unsupportedMessage = fmt.Sprintf("%s (%s)", output, err)


### PR DESCRIPTION
Performing reverse dns lookups during setup can take a long time, especially if they timeout because gluetun is restarting and the requests are blocked (and thus only return after a long timeout).