### PR TITLE
Increase healthcheck dial timeout for improved stability

### DIFF
--- a/internal/configuration/settings/healthywait.go
+++ b/internal/configuration/settings/healthywait.go
@@ -40,7 +40,7 @@ func (h *HealthyWait) overrideWith(other HealthyWait) {
 }
 
 func (h *HealthyWait) setDefaults() {
-	const initialDurationDefault = 6 * time.Second
+	const initialDurationDefault = 60 * time.Second
 	const additionDurationDefault = 5 * time.Second
 	h.Initial = gosettings.DefaultPointer(h.Initial, initialDurationDefault)
 	h.Addition = gosettings.DefaultPointer(h.Addition, additionDurationDefault)

--- a/internal/healthcheck/health.go
+++ b/internal/healthcheck/health.go
@@ -15,13 +15,10 @@ func (s *Server) runHealthcheckLoop(ctx context.Context, done chan<- struct{}) {
 
 	timeoutIndex := 0
 	healthcheckTimeouts := []time.Duration{
-		2 * time.Second,
-		4 * time.Second,
-		6 * time.Second,
-		8 * time.Second,
+		30 * time.Second,
 		// This can be useful when the connection is under stress
 		// See https://github.com/qdm12/gluetun/issues/2270
-		10 * time.Second,
+		60 * time.Second,
 	}
 	s.vpn.healthyTimer = time.NewTimer(s.vpn.healthyWait)
 
@@ -43,7 +40,7 @@ func (s *Server) runHealthcheckLoop(ctx context.Context, done chan<- struct{}) {
 			s.vpn.healthyTimer.Stop()
 			s.vpn.healthyWait = *s.config.VPN.Initial
 		case previousErr == nil && err != nil: // First failure
-			s.logger.Debug("unhealthy: " + err.Error())
+			s.logger.Info("unhealthy: " + err.Error())
 			s.vpn.healthyTimer.Stop()
 			s.vpn.healthyTimer = time.NewTimer(s.vpn.healthyWait)
 		case previousErr != nil && err != nil: // Nth failure


### PR DESCRIPTION
Increases the healthcheck timeouts to improve stability. With this, I haven't seen any disconnects from ProtonVPN using default settings after days, instead of constant ~15-30m reconnects.

* The healthcheck timeouts are now 30s for the first connection, and up to 60s for a second attempt
* Adjusted the initial (first failure) timeout to 60s, to match with the longer healthcheck timeout
* Changed the `unhealthy` log to INFO, because otherwise the log message just shows `healthy!` over and over again without context that the healthcheck was found unhealthy, and why

Docker image available at `ghcr.io/ls0t/gluetun:latest`

Should fix https://github.com/qdm12/gluetun/issues/2154, https://github.com/qdm12/gluetun/issues/2270