### PR TITLE
Upgrade ci actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     env:
       DOCKER_BUILDKIT: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: reviewdog/action-misspell@v1
         with:
@@ -73,10 +73,10 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: "^1.23"
+          go-version-file: go.mod
       - uses: github/codeql-action/init@v3
         with:
           languages: go
@@ -98,7 +98,7 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: crazy-max/ghaction-github-labeler@v5
         with:
           yaml-file: .github/labels.yml

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -18,9 +18,9 @@ jobs:
       actions: read
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: DavidAnson/markdownlint-cli2-action@v19
+      - uses: DavidAnson/markdownlint-cli2-action@v20
         with:
           globs: "**.md"
           config: .markdownlint.json


### PR DESCRIPTION
Upgrade github actions.
setup-go action relies on go mod file rather than hard coded.