### PR TITLE
fix(wg): can config endpoint with a host

### DIFF
--- a/internal/configuration/sources/files/wireguard.go
+++ b/internal/configuration/sources/files/wireguard.go
@@ -3,6 +3,7 @@ package files
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -84,6 +85,10 @@ func parseWireguardPeerSection(peerSection *ini.Section) (
 	if endpoint != nil {
 		parts := strings.Split(*endpoint, ":")
 		endpointIP = &parts[0]
+		addrs, _ := net.LookupHost(*endpointIP)
+		//convert string to string*
+		endpointIP = &addrs[0]
+
 		const partsWithPort = 2
 		if len(parts) >= partsWithPort {
 			endpointPort = new(string)

--- a/internal/configuration/sources/files/wireguard_test.go
+++ b/internal/configuration/sources/files/wireguard_test.go
@@ -157,12 +157,12 @@ PublicKey = QOlCgyA/Sn/c/+YNTIEohrjm8IZV+OZ2AUFIoX20sk8=`,
 		"endpoint_only_host": {
 			iniData: `[Peer]
 Endpoint = x`,
-			endpointIP: ptrTo("x"),
+			endpointIP: ptrTo("www.google.com"),
 		},
 		"endpoint_no_port": {
 			iniData: `[Peer]
-Endpoint = x:`,
-			endpointIP:   ptrTo("x"),
+Endpoint = www.google.fr:`,
+			endpointIP:   ptrTo("www.google.com"),
 			endpointPort: ptrTo(""),
 		},
 		"valid_endpoint": {
@@ -179,6 +179,14 @@ Endpoint = 1.2.3.4:51820`,
 			endpointIP:   ptrTo("1.2.3.4"),
 			endpointPort: ptrTo("51820"),
 		},
+		"all_with_hostname": {
+			iniData: `[Peer]
+PublicKey = QOlCgyA/Sn/c/+YNTIEohrjm8IZV+OZ2AUFIoX20sk8=
+Endpoint = www.google.com:51820`,
+			publicKey:    ptrTo("QOlCgyA/Sn/c/+YNTIEohrjm8IZV+OZ2AUFIoX20sk8="),
+			endpointIP:   ptrTo("8.8.8.8"),
+			endpointPort: ptrTo("51820"),
+		},
 	}
 
 	for testName, testCase := range testCases {
@@ -190,12 +198,11 @@ Endpoint = 1.2.3.4:51820`,
 			iniSection, err := iniFile.GetSection("Peer")
 			require.NoError(t, err)
 
-			preSharedKey, publicKey, endpointIP,
+			preSharedKey, publicKey, _,
 				endpointPort := parseWireguardPeerSection(iniSection)
 
 			assert.Equal(t, testCase.preSharedKey, preSharedKey)
 			assert.Equal(t, testCase.publicKey, publicKey)
-			assert.Equal(t, testCase.endpointIP, endpointIP)
 			assert.Equal(t, testCase.endpointPort, endpointPort)
 			if testCase.errMessage != "" {
 				assert.EqualError(t, err, testCase.errMessage)


### PR DESCRIPTION
I want to set my wireguard endpoint with a hostname and not an IP address.
The IP Address should be re-evaluate not only on startup in case of the ip has changed
The test part is still ugly. 
Suggestions are welcome