### PR TITLE
feat(dns): resolve network-local names

### DIFF
--- a/internal/dns/loop.go
+++ b/internal/dns/loop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/netip"
 	"time"
 
 	"github.com/qdm12/dns/v2/pkg/middlewares/filter/mapfilter"
@@ -16,22 +17,23 @@ import (
 )
 
 type Loop struct {
-	statusManager *loopstate.State
-	state         *state.State
-	server        *server.Server
-	filter        *mapfilter.Filter
-	resolvConf    string
-	client        *http.Client
-	logger        Logger
-	userTrigger   bool
-	start         <-chan struct{}
-	running       chan<- models.LoopStatus
-	stop          <-chan struct{}
-	stopped       chan<- struct{}
-	updateTicker  <-chan struct{}
-	backoffTime   time.Duration
-	timeNow       func() time.Time
-	timeSince     func(time.Time) time.Duration
+	statusManager  *loopstate.State
+	state          *state.State
+	server         *server.Server
+	filter         *mapfilter.Filter
+	localResolvers []netip.AddrPort
+	resolvConf     string
+	client         *http.Client
+	logger         Logger
+	userTrigger    bool
+	start          <-chan struct{}
+	running        chan<- models.LoopStatus
+	stop           <-chan struct{}
+	stopped        chan<- struct{}
+	updateTicker   <-chan struct{}
+	backoffTime    time.Duration
+	timeNow        func() time.Time
+	timeSince      func(time.Time) time.Duration
 }
 
 const defaultBackoffTime = 10 * time.Second

--- a/internal/dns/run.go
+++ b/internal/dns/run.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 
+	"github.com/qdm12/dns/v2/pkg/nameserver"
 	"github.com/qdm12/gluetun/internal/constants"
 )
 
 func (l *Loop) Run(ctx context.Context, done chan<- struct{}) {
 	defer close(done)
+
+	l.localResolvers = nameserver.GetPrivateDNSServers()
 
 	if *l.GetSettings().KeepNameserver {
 		l.logger.Warn("⚠️⚠️⚠️  keeping the default container nameservers, " +

--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -21,7 +21,7 @@ func (l *Loop) setupServer(ctx context.Context) (runError <-chan error, err erro
 
 	settings := l.GetSettings()
 
-	serverSettings, err := buildServerSettings(settings, l.filter, l.logger)
+	serverSettings, err := buildServerSettings(settings, l.filter, l.localResolvers, l.logger)
 	if err != nil {
 		return nil, fmt.Errorf("building server settings: %w", err)
 	}


### PR DESCRIPTION
WHY: To finally be able to resolve container names present in the same container network as Gluetun.
**WHAT I NEED FROM YOU** 🆘 : What is your current usage of `DNS_KEEP_NAMESERVER` or `SERVER_ADDRESS`?

NEXT STEPS:
1. Always enable the built-in DNS forwarder server (older `DOT` gone`) so that local names can always resolve
2. Remove `DNS_KEEP_NAMESERVER`. It should now be unneeded as far as I know.
3. Repurpose the `DNS_ADDRESS` such that:
    - if set to `127.0.0.1` (current default): ignore it
    - if it is without a port (current format): have the DNS forwarder server use it as the upstream resolver and force the upstream type to plain (=udp port 53)
    - otherwise (with a port specified, new format): have the DNS forwarder server use it as the upstream resolver and use the  upstream type as defined by `DNS_UPSTREAM_RESOLVER_TYPE`

---

On this PR:

You can run it with tag `:pr-2970`. No other configuration needed.

This is handled by a middleware built-in the local DNS forwarding server. Local names are queried to the private nameservers found in /etc/resolv.conf at container start (i.e. 127.0.0.11 for a Docker bridge network), and forwarded back to clients. That way you can have both DNS over TLS (with caching, filtering etc.) + local container names. Note non-local names AND local names not resolved are both then handled by the normal DNS over TLS pipeline (including filtering, caching etc.)

Small additional notes for this PR:

- having DOT=off or DNS_SERVER=off will cause the local resolution to no longer work, since it's built-in the local forwarder server
