### PR TITLE
fix(publicip/api/cloudflare): add `Referer` header

### DIFF
--- a/internal/publicip/api/cloudflare.go
+++ b/internal/publicip/api/cloudflare.go
@@ -40,7 +40,8 @@ func (c *cloudflare) Token() (token string) {
 func (c *cloudflare) FetchInfo(ctx context.Context, ip netip.Addr) (
 	result models.PublicIP, err error,
 ) {
-	url := "https://speed.cloudflare.com/meta"
+	urlBase := "https://speed.cloudflare.com"
+	url := urlBase + "/meta"
 	if ip.IsValid() {
 		return result, fmt.Errorf("%w: cloudflare cannot provide information on the arbitrary IP address %s",
 			ErrServiceLimited, ip)
@@ -50,6 +51,7 @@ func (c *cloudflare) FetchInfo(ctx context.Context, ip netip.Addr) (
 	if err != nil {
 		return result, err
 	}
+	request.Header.Add("Referer", urlBase) // returns HTTP 403 otherwise
 
 	response, err := c.client.Do(request)
 	if err != nil {


### PR DESCRIPTION
# Description

The Cloudflare API now returns HTTP 403 without an appropriate `Referer` header

# Issue

None

# Assertions

* [x] I am aware that we do not accept manual changes to the servers.json file <!-- If this is your goal, please consult https://github.com/qdm12/gluetun-wiki/blob/main/setup/servers.md#update-using-the-command-line -->
* [x] I am aware that any changes to settings should be reflected in the [wiki](https://github.com/qdm12/gluetun-wiki/)
