### PR TITLE
feat(privado): add URL override for authenticated server list access

### DIFF
--- a/internal/provider/privado/updater/servers.go
+++ b/internal/provider/privado/updater/servers.go
@@ -21,7 +21,7 @@ func (u *Updater) FetchServers(ctx context.Context, minServers int) (
 
 	url := os.Getenv("PRIVADO_OVPN_URL")
 	if url == "" {
-			url = "https://privadovpn.com/apps/ovpn_configs.zip"
+		url = "https://privadovpn.com/apps/ovpn_configs.zip"
 	}
 
 	contents, err := u.unzipper.FetchAndExtract(ctx, url)


### PR DESCRIPTION
# Description

Adds `PRIVADO_OVPN_URL` environment variable to allow overriding the default Privado config URL. This enables access to the full authenticated server list instead of the limited public list, by self-hosting the full list and accessing it through the updater.

# Issue

The default `https://privadovpn.com/apps/ovpn_configs.zip` endpoint only returns a subset of servers when unauthenticated.

#2876 #2118

# Assertions

* [x] I am aware that we do not accept manual changes to the servers.json file
* [x] I am aware that any changes to settings should be reflected in the [wiki](https://github.com/qdm12/gluetun-wiki/)