### PR TITLE
feat: add socks5 proxy server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,6 +196,14 @@ ENV VPN_SERVICE_PROVIDER=pia \
     HTTPPROXY_PASSWORD= \
     HTTPPROXY_USER_SECRETFILE=/run/secrets/httpproxy_user \
     HTTPPROXY_PASSWORD_SECRETFILE=/run/secrets/httpproxy_password \
+    # SOCKS5
+    SOCKS5=off \
+    SOCKS5_LOG=off \
+    SOCKS5_LISTENING_ADDRESS=":1080" \
+    SOCKS5_USER= \
+    SOCKS5_PASSWORD= \
+    SOCKS5_USER_SECRETFILE=/run/secrets/socks5_user \
+    SOCKS5_PASSWORD_SECRETFILE=/run/secrets/socks5_password \
     # Shadowsocks
     SHADOWSOCKS=off \
     SHADOWSOCKS_LOG=off \
@@ -232,7 +240,7 @@ ENV VPN_SERVICE_PROVIDER=pia \
     PUID=1000 \
     PGID=1000
 ENTRYPOINT ["/gluetun-entrypoint"]
-EXPOSE 8000/tcp 8888/tcp 8388/tcp 8388/udp
+EXPOSE 8000/tcp 8888/tcp 1080/tcp 8388/tcp 8388/udp
 HEALTHCHECK --interval=5s --timeout=5s --start-period=10s --retries=3 CMD /gluetun-entrypoint healthcheck
 ARG TARGETPLATFORM
 RUN apk add --no-cache --update -l wget && \

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Lightweight swiss-army-knife-like VPN client to multiple VPN service providers
 - Built in firewall kill switch to allow traffic only with needed the VPN servers and LAN devices
 - Built in Shadowsocks proxy server (protocol based on SOCKS5 with an encryption layer, tunnels TCP+UDP)
 - Built in HTTP proxy (tunnels HTTP and HTTPS through TCP)
+- Built in SOCKS5 proxy (tunnels TCP)
 - [Connect other containers to it](https://github.com/qdm12/gluetun-wiki/blob/main/setup/connect-a-container-to-gluetun.md)
 - [Connect LAN devices to it](https://github.com/qdm12/gluetun-wiki/blob/main/setup/connect-a-lan-device-to-gluetun.md)
 - Compatible with amd64, i686 (32 bit), **ARM** 64 bit, ARM 32 bit v6 and v7, and even ppc64le 🎆
@@ -102,6 +103,7 @@ services:
       - /dev/net/tun:/dev/net/tun
     ports:
       - 8888:8888/tcp # HTTP proxy
+      - 1080:1080/tcp # SOCKS5
       - 8388:8388/tcp # Shadowsocks
       - 8388:8388/udp # Shadowsocks
     volumes:

--- a/cmd/gluetun/main.go
+++ b/cmd/gluetun/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/qdm12/gluetun/internal/publicip"
 	"github.com/qdm12/gluetun/internal/routing"
 	"github.com/qdm12/gluetun/internal/server"
+	"github.com/qdm12/gluetun/internal/socks5"
 	"github.com/qdm12/gluetun/internal/shadowsocks"
 	"github.com/qdm12/gluetun/internal/storage"
 	"github.com/qdm12/gluetun/internal/tun"
@@ -473,6 +474,13 @@ func _main(ctx context.Context, buildInfo models.BuildInformation,
 		"shadowsocks proxy", goroutine.OptionTimeout(defaultShutdownTimeout))
 	go shadowsocksLooper.Run(shadowsocksCtx, shadowsocksDone)
 	otherGroupHandler.Add(shadowsocksHandler)
+
+	socks5Looper := socks5.NewLoop(allSettings.Socks5,
+		logger.New(log.SetComponent("socks5")))
+	socks5Handler, socks5Ctx, socks5Done := goshutdown.NewGoRoutineHandler(
+		"socks5 proxy", goroutine.OptionTimeout(defaultShutdownTimeout))
+	go socks5Looper.Run(socks5Ctx, socks5Done)
+	otherGroupHandler.Add(socks5Handler)
 
 	httpServerHandler, httpServerCtx, httpServerDone := goshutdown.NewGoRoutineHandler(
 		"http server", goroutine.OptionTimeout(defaultShutdownTimeout))

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/ProtonMail/go-srp v0.0.7
+	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/breml/rootcerts v0.3.3
 	github.com/fatih/color v1.18.0
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/ProtonMail/go-crypto v1.3.0-proton h1:tAQKQRZX/73VmzK6yHSCaRUOvS/3OYS
 github.com/ProtonMail/go-crypto v1.3.0-proton/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
 github.com/ProtonMail/go-srp v0.0.7 h1:Sos3Qk+th4tQR64vsxGIxYpN3rdnG9Wf9K4ZloC1JrI=
 github.com/ProtonMail/go-srp v0.0.7/go.mod h1:giCp+7qRnMIcCvI6V6U3S1lDDXDQYx2ewJ6F/9wdlJk=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/breml/rootcerts v0.3.3 h1://GnaRtQ/9BY2+GtMk2wtWxVdCRysiaPr5/xBwl7NKw=

--- a/internal/configuration/settings/settings.go
+++ b/internal/configuration/settings/settings.go
@@ -22,6 +22,7 @@ type Settings struct {
 	Log           Log
 	PublicIP      PublicIP
 	Shadowsocks   Shadowsocks
+	Socks5        Socks5
 	Storage       Storage
 	System        System
 	Updater       Updater
@@ -49,6 +50,7 @@ func (s *Settings) Validate(filterChoicesGetter FilterChoicesGetter, ipv6Support
 		"log":             s.Log.validate,
 		"public ip check": s.PublicIP.validate,
 		"shadowsocks":     s.Shadowsocks.validate,
+		"socks5":          s.Socks5.validate,
 		"storage":         s.Storage.validate,
 		"system":          s.System.validate,
 		"updater":         s.Updater.Validate,
@@ -79,6 +81,7 @@ func (s *Settings) copy() (copied Settings) {
 		Log:           s.Log.copy(),
 		PublicIP:      s.PublicIP.copy(),
 		Shadowsocks:   s.Shadowsocks.copy(),
+		Socks5:        s.Socks5.copy(),
 		Storage:       s.Storage.copy(),
 		System:        s.System.copy(),
 		Updater:       s.Updater.copy(),
@@ -100,6 +103,7 @@ func (s *Settings) OverrideWith(other Settings,
 	patchedSettings.Log.overrideWith(other.Log)
 	patchedSettings.PublicIP.overrideWith(other.PublicIP)
 	patchedSettings.Shadowsocks.overrideWith(other.Shadowsocks)
+	patchedSettings.Socks5.overrideWith(other.Socks5)
 	patchedSettings.Storage.overrideWith(other.Storage)
 	patchedSettings.System.overrideWith(other.System)
 	patchedSettings.Updater.overrideWith(other.Updater)
@@ -123,6 +127,7 @@ func (s *Settings) SetDefaults() {
 	s.Log.setDefaults()
 	s.PublicIP.setDefaults()
 	s.Shadowsocks.setDefaults()
+	s.Socks5.setDefaults()
 	s.Storage.setDefaults()
 	s.System.setDefaults()
 	s.Version.setDefaults()
@@ -144,6 +149,7 @@ func (s Settings) toLinesNode() (node *gotree.Node) {
 	node.AppendNode(s.Log.toLinesNode())
 	node.AppendNode(s.Health.toLinesNode())
 	node.AppendNode(s.Shadowsocks.toLinesNode())
+	node.AppendNode(s.Socks5.toLinesNode())
 	node.AppendNode(s.HTTPProxy.toLinesNode())
 	node.AppendNode(s.ControlServer.toLinesNode())
 	node.AppendNode(s.Storage.toLinesNode())
@@ -203,6 +209,7 @@ func (s *Settings) Read(r *reader.Reader, warner Warner) (err error) {
 			return s.PublicIP.read(r, warner)
 		},
 		"shadowsocks": s.Shadowsocks.read,
+		"socks5":      s.Socks5.read,
 		"storage":     s.Storage.read,
 		"system":      s.System.read,
 		"updater":     s.Updater.read,

--- a/internal/configuration/settings/settings_test.go
+++ b/internal/configuration/settings/settings_test.go
@@ -67,6 +67,8 @@ func Test_Settings_String(t *testing.T) {
 |   └── Restart VPN on healthcheck failure: yes
 ├── Shadowsocks server settings:
 |   └── Enabled: no
+├── SOCKS5 server settings:
+|   └── Enabled: no
 ├── HTTP proxy settings:
 |   └── Enabled: no
 ├── Control server settings:

--- a/internal/configuration/settings/socks5.go
+++ b/internal/configuration/settings/socks5.go
@@ -1,0 +1,100 @@
+package settings
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/qdm12/gosettings"
+	"github.com/qdm12/gosettings/reader"
+	"github.com/qdm12/gosettings/validate"
+	"github.com/qdm12/gotree"
+)
+
+// Socks5 contains settings to configure the SOCKS5 server.
+type Socks5 struct {
+	// Enabled is true if the server should be running.
+	// It defaults to false, and cannot be nil in the internal state.
+	Enabled *bool
+	ListeningAddress string
+	User *string
+	Password *string
+	Log *bool
+}
+
+func (s Socks5) validate() (err error) {
+	err = validate.ListeningAddress(s.ListeningAddress, os.Getuid())
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrServerAddressNotValid, s.ListeningAddress)
+	}
+	return nil
+}
+
+func (s *Socks5) copy() (copied Socks5) {
+	return Socks5{
+		Enabled:          gosettings.CopyPointer(s.Enabled),
+		ListeningAddress: s.ListeningAddress,
+		User:             gosettings.CopyPointer(s.User),
+		Password:         gosettings.CopyPointer(s.Password),
+		Log:              gosettings.CopyPointer(s.Log),
+	}
+}
+
+// overrideWith overrides fields of the receiver
+// settings object with any field set in the other
+// settings.
+func (s *Socks5) overrideWith(other Socks5) {
+	s.Enabled = gosettings.OverrideWithPointer(s.Enabled, other.Enabled)
+	s.ListeningAddress = gosettings.OverrideWithComparable(s.ListeningAddress, other.ListeningAddress)
+	s.User = gosettings.OverrideWithPointer(s.User, other.User)
+	s.Password = gosettings.OverrideWithPointer(s.Password, other.Password)
+	s.Log = gosettings.OverrideWithPointer(s.Log, other.Log)
+}
+
+func (s *Socks5) setDefaults() {
+	s.Enabled = gosettings.DefaultPointer(s.Enabled, false)
+	s.ListeningAddress = gosettings.DefaultComparable(s.ListeningAddress, ":1080")
+	s.User = gosettings.DefaultPointer(s.User, "")
+	s.Password = gosettings.DefaultPointer(s.Password, "")
+	s.Log = gosettings.DefaultPointer(s.Log, false)
+}
+
+func (s Socks5) String() string {
+	return s.toLinesNode().String()
+}
+
+func (s Socks5) toLinesNode() (node *gotree.Node) {
+	node = gotree.New("SOCKS5 server settings:")
+
+	node.Appendf("Enabled: %s", gosettings.BoolToYesNo(s.Enabled))
+	if !*s.Enabled {
+		return node
+	}
+
+	node.Appendf("Listening address: %s", s.ListeningAddress)
+	node.Appendf("User: %s", *s.User)
+	node.Appendf("Password: %s", gosettings.ObfuscateKey(*s.Password))
+	node.Appendf("Log: %s", gosettings.BoolToYesNo(s.Log))
+
+	return node
+}
+
+func (s *Socks5) read(r *reader.Reader) (err error) {
+	s.Enabled, err = r.BoolPtr("SOCKS5")
+	if err != nil {
+		return err
+	}
+
+	s.ListeningAddress = r.String("SOCKS5_LISTENING_ADDRESS")
+
+	s.User = r.Get("SOCKS5_USER",
+		reader.ForceLowercase(false))
+	s.Password = r.Get("SOCKS5_PASSWORD",
+		reader.ForceLowercase(false))
+
+	s.Log, err = r.BoolPtr("SOCKS5_LOG")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/socks5/logger.go
+++ b/internal/socks5/logger.go
@@ -1,0 +1,19 @@
+package socks5
+
+type Logger interface {
+	debuger
+	infoer
+	errorer
+}
+
+type debuger interface {
+	Debug(s string)
+}
+
+type infoer interface {
+	Info(s string)
+}
+
+type errorer interface {
+	Error(s string)
+}

--- a/internal/socks5/loop.go
+++ b/internal/socks5/loop.go
@@ -1,0 +1,135 @@
+package socks5
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/qdm12/gluetun/internal/configuration/settings"
+	"github.com/qdm12/gluetun/internal/constants"
+	"github.com/qdm12/gluetun/internal/models"
+)
+
+type Loop struct {
+	state state
+	// Other objects
+	logger Logger
+	// Internal channels and locks
+	loopLock      sync.Mutex
+	running       chan models.LoopStatus
+	stop, stopped chan struct{}
+	start         chan struct{}
+	backoffTime   time.Duration
+}
+
+const defaultBackoffTime = 10 * time.Second
+
+func NewLoop(settings settings.Socks5, logger Logger) *Loop {
+	return &Loop{
+		state: state{
+			status:   constants.Stopped,
+			settings: settings,
+		},
+		logger:      logger,
+		start:       make(chan struct{}),
+		running:     make(chan models.LoopStatus),
+		stop:        make(chan struct{}),
+		stopped:     make(chan struct{}),
+		backoffTime: defaultBackoffTime,
+	}
+}
+
+func (l *Loop) logAndWait(ctx context.Context, err error) {
+	if err != nil {
+		l.logger.Error(err.Error())
+	}
+	l.logger.Info("retrying in " + l.backoffTime.String())
+	timer := time.NewTimer(l.backoffTime)
+	l.backoffTime *= 2
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+		if !timer.Stop() {
+			<-timer.C
+		}
+	}
+}
+
+func (l *Loop) Run(ctx context.Context, done chan<- struct{}) {
+	defer close(done)
+
+	crashed := false
+
+	if *l.GetSettings().Enabled {
+		go func() {
+			_, _ = l.SetStatus(ctx, constants.Running)
+		}()
+	}
+
+	select {
+	case <-l.start:
+	case <-ctx.Done():
+		return
+	}
+
+	for ctx.Err() == nil {
+		settings := l.GetSettings()
+		server, listener, err := newServer(settings, l.logger)
+		if err != nil {
+			crashed = true
+			l.logAndWait(ctx, err)
+			continue
+		}
+
+		waitError := make(chan error)
+		go func() {
+			waitError <- server.Serve(listener)
+		}()
+
+		isStableTimer := time.NewTimer(time.Second)
+
+		stayHere := true
+		for stayHere {
+			select {
+			case <-ctx.Done():
+				_ = listener.Close()
+				<-waitError
+				close(waitError)
+				return
+			case <-isStableTimer.C:
+				if !crashed {
+					l.running <- constants.Running
+					crashed = false
+				} else {
+					l.backoffTime = defaultBackoffTime
+					l.state.setStatusWithLock(constants.Running)
+				}
+			case <-l.start:
+				l.logger.Info("starting")
+				_ = listener.Close()
+				<-waitError
+				close(waitError)
+				stayHere = false
+			case <-l.stop:
+				l.logger.Info("stopping")
+				_ = listener.Close()
+				<-waitError
+				close(waitError)
+				l.stopped <- struct{}{}
+			case err := <-waitError: // unexpected error
+				_ = listener.Close()
+				close(waitError)
+				if ctx.Err() != nil {
+					return
+				}
+				l.state.setStatusWithLock(constants.Crashed)
+				l.logAndWait(ctx, err)
+				crashed = true
+				stayHere = false
+			}
+		}
+		if !isStableTimer.Stop() {
+			<-isStableTimer.C
+		}
+	}
+}

--- a/internal/socks5/server.go
+++ b/internal/socks5/server.go
@@ -1,0 +1,59 @@
+package socks5
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strings"
+
+	sockslib "github.com/armon/go-socks5"
+	"github.com/qdm12/gluetun/internal/configuration/settings"
+)
+
+func newServer(settings settings.Socks5, logger Logger) (server *sockslib.Server, listener net.Listener, err error) {
+	conf := &sockslib.Config{
+		Logger: newSocks5Logger(logger, settings),
+	}
+
+	if settings.User != nil && *settings.User != "" {
+		creds := sockslib.StaticCredentials{
+			*settings.User: *settings.Password,
+		}
+		conf.AuthMethods = []sockslib.Authenticator{
+			&sockslib.UserPassAuthenticator{Credentials: creds},
+		}
+		conf.Credentials = creds
+	}
+
+	server, err = sockslib.New(conf)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating SOCKS5 server: %w", err)
+	}
+
+	listener, err = net.Listen("tcp", settings.ListeningAddress)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listening on %s: %w", settings.ListeningAddress, err)
+	}
+
+	return server, listener, nil
+}
+
+func newSocks5Logger(logger Logger, settings settings.Socks5) *log.Logger {
+	if settings.Log == nil || !*settings.Log {
+		return log.New(io.Discard, "", 0)
+	}
+	return log.New(&socks5LogWriter{logger: logger}, "", 0)
+}
+
+type socks5LogWriter struct {
+	logger Logger
+}
+
+func (w *socks5LogWriter) Write(p []byte) (n int, err error) {
+	message := strings.TrimSpace(string(p))
+	if message != "" {
+		w.logger.Info(message)
+	}
+	return len(p), nil
+}

--- a/internal/socks5/server_test.go
+++ b/internal/socks5/server_test.go
@@ -1,0 +1,114 @@
+package socks5
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/qdm12/gluetun/internal/configuration/settings"
+	"github.com/stretchr/testify/require"
+)
+
+type testLogger struct {
+	infos []string
+}
+
+func (l *testLogger) Debug(string) {}
+func (l *testLogger) Error(string) {}
+func (l *testLogger) Info(s string) { l.infos = append(l.infos, s) }
+
+func ptrTo[T any](value T) *T { return &value }
+
+func Test_newServer_NoAuth(t *testing.T) {
+	t.Parallel()
+
+	logger := &testLogger{}
+	settings := settings.Socks5{
+		Enabled:          ptrTo(true),
+		ListeningAddress: "127.0.0.1:0",
+		User:             ptrTo(""),
+		Password:         ptrTo(""),
+		Log:              ptrTo(false),
+	}
+
+	server, listener, err := newServer(settings, logger)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- server.Serve(listener)
+	}()
+
+	conn, err := net.DialTimeout("tcp", listener.Addr().String(), time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+
+	// Client greeting: version 5, 1 method: no-auth (0x00)
+	_, err = conn.Write([]byte{0x05, 0x01, 0x00})
+	require.NoError(t, err)
+
+	resp := make([]byte, 2)
+	_, err = conn.Read(resp)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x05), resp[0])
+	require.Equal(t, byte(0x00), resp[1])
+
+	_ = listener.Close()
+	<-serveErr
+}
+
+func Test_newServer_UserPassAuth(t *testing.T) {
+	t.Parallel()
+
+	logger := &testLogger{}
+	settings := settings.Socks5{
+		Enabled:          ptrTo(true),
+		ListeningAddress: "127.0.0.1:0",
+		User:             ptrTo("user"),
+		Password:         ptrTo("pass"),
+		Log:              ptrTo(false),
+	}
+
+	server, listener, err := newServer(settings, logger)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- server.Serve(listener)
+	}()
+
+	conn, err := net.DialTimeout("tcp", listener.Addr().String(), time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+
+	// Client greeting: version 5, 2 methods: no-auth (0x00), user/pass (0x02)
+	_, err = conn.Write([]byte{0x05, 0x02, 0x00, 0x02})
+	require.NoError(t, err)
+
+	resp := make([]byte, 2)
+	_, err = conn.Read(resp)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x05), resp[0])
+	require.Equal(t, byte(0x02), resp[1])
+
+	// Username/password auth (RFC 1929)
+	_, err = conn.Write([]byte{
+		0x01, // auth version
+		0x04, 'u', 's', 'e', 'r',
+		0x04, 'p', 'a', 's', 's',
+	})
+	require.NoError(t, err)
+
+	authResp := make([]byte, 2)
+	_, err = conn.Read(authResp)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x01), authResp[0])
+	require.Equal(t, byte(0x00), authResp[1])
+
+	_ = listener.Close()
+	<-serveErr
+}

--- a/internal/socks5/state.go
+++ b/internal/socks5/state.go
@@ -1,0 +1,119 @@
+package socks5
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/qdm12/gluetun/internal/configuration/settings"
+	"github.com/qdm12/gluetun/internal/constants"
+	"github.com/qdm12/gluetun/internal/models"
+)
+
+type state struct {
+	status     models.LoopStatus
+	settings   settings.Socks5
+	statusMu   sync.RWMutex
+	settingsMu sync.RWMutex
+}
+
+func (s *state) setStatusWithLock(status models.LoopStatus) {
+	s.statusMu.Lock()
+	defer s.statusMu.Unlock()
+	s.status = status
+}
+
+func (l *Loop) GetStatus() (status models.LoopStatus) {
+	l.state.statusMu.RLock()
+	defer l.state.statusMu.RUnlock()
+	return l.state.status
+}
+
+var ErrInvalidStatus = errors.New("invalid status")
+
+func (l *Loop) SetStatus(ctx context.Context, status models.LoopStatus) (
+	outcome string, err error,
+) {
+	l.state.statusMu.Lock()
+	defer l.state.statusMu.Unlock()
+	existingStatus := l.state.status
+
+	switch status {
+	case constants.Running:
+		switch existingStatus {
+		case constants.Starting, constants.Running, constants.Stopping, constants.Crashed:
+			return fmt.Sprintf("already %s", existingStatus), nil
+		}
+		l.loopLock.Lock()
+		defer l.loopLock.Unlock()
+		l.state.status = constants.Starting
+		l.state.statusMu.Unlock()
+		l.start <- struct{}{}
+
+		newStatus := constants.Starting // for canceled context
+		select {
+		case <-ctx.Done():
+		case newStatus = <-l.running:
+		}
+		l.state.statusMu.Lock()
+		l.state.status = newStatus
+		return newStatus.String(), nil
+	case constants.Stopped:
+		switch existingStatus {
+		case constants.Stopped, constants.Stopping, constants.Starting, constants.Crashed:
+			return fmt.Sprintf("already %s", existingStatus), nil
+		}
+		l.loopLock.Lock()
+		defer l.loopLock.Unlock()
+		l.state.status = constants.Stopping
+		l.state.statusMu.Unlock()
+		l.stop <- struct{}{}
+		newStatus := constants.Stopping // for canceled context
+		select {
+		case <-ctx.Done():
+		case <-l.stopped:
+			newStatus = constants.Stopped
+		}
+		l.state.statusMu.Lock()
+		l.state.status = newStatus
+		return status.String(), nil
+	default:
+		return "", fmt.Errorf("%w: %s: it can only be one of: %s, %s",
+			ErrInvalidStatus, status, constants.Running, constants.Stopped)
+	}
+}
+
+func (l *Loop) GetSettings() (settings settings.Socks5) {
+	l.state.settingsMu.RLock()
+	defer l.state.settingsMu.RUnlock()
+	return l.state.settings
+}
+
+func (l *Loop) SetSettings(ctx context.Context, settings settings.Socks5) (
+	outcome string,
+) {
+	l.state.settingsMu.Lock()
+	settingsUnchanged := reflect.DeepEqual(settings, l.state.settings)
+	if settingsUnchanged {
+		l.state.settingsMu.Unlock()
+		return "settings left unchanged"
+	}
+	newEnabled := *settings.Enabled
+	previousEnabled := *l.state.settings.Enabled
+	l.state.settings = settings
+	l.state.settingsMu.Unlock()
+	// Either restart or set changed status
+	switch {
+	case !newEnabled && !previousEnabled:
+	case newEnabled && previousEnabled:
+		_, _ = l.SetStatus(ctx, constants.Stopped)
+		_, _ = l.SetStatus(ctx, constants.Running)
+	case newEnabled && !previousEnabled:
+		_, _ = l.SetStatus(ctx, constants.Running)
+	case !newEnabled && previousEnabled:
+		_, _ = l.SetStatus(ctx, constants.Stopped)
+	}
+	return "settings updated"
+}


### PR DESCRIPTION
# Description

I would like to add simple socks5 functionality. I know shadowsocks exists already but not all tools can use it. It's a long requested [feature](https://github.com/qdm12/gluetun/issues/234). 

I am not a Go developer and I implemented this by adding a new dependency that maybe is not the preferred way considering you have implemented an ss-server to use here for shadowsocks. The [dependency I added](https://github.com/armon/go-socks5) is ancient but seems stable enough and with no obvious (to me) flaws. I can change it to something else if needed. But anyways, as I implemented the feature and I am actively using it, I thought of creating a PR.  

If it's going to be accepted I can create a PR for the wiki also.

# Issue

https://github.com/qdm12/gluetun/issues/234

# Assertions

* [X] I am aware that we do not accept manual changes to the servers.json file
* [X] I am aware that any changes to settings should be reflected in the [wiki](https://github.com/qdm12/gluetun-wiki/)
