### PR TITLE
fix(openvpn): bundle provider CA certificates in one block

### DIFF
--- a/internal/provider/utils/openvpn.go
+++ b/internal/provider/utils/openvpn.go
@@ -175,8 +175,8 @@ func OpenVPNConfig(provider OpenVPNProviderSettings,
 		lines.add("setenv", envKey, envValue)
 	}
 
-	for _, ca := range provider.CAs {
-		lines.addLines(WrapOpenvpnCA(ca))
+	if len(provider.CAs) > 0 {
+		lines.addLines(WrapOpenvpnCAs(provider.CAs))
 	}
 	if provider.CRLVerify != "" {
 		lines.addLines(WrapOpenvpnCRLVerify(provider.CRLVerify))
@@ -268,13 +268,20 @@ func defaultStringSlice(value, defaultValue []string) (
 }
 
 func WrapOpenvpnCA(certificate string) (lines []string) {
-	return []string{
-		"<ca>",
-		"-----BEGIN CERTIFICATE-----",
-		certificate,
-		"-----END CERTIFICATE-----",
-		"</ca>",
+	return WrapOpenvpnCAs([]string{certificate})
+}
+
+func WrapOpenvpnCAs(certificates []string) (lines []string) {
+	lines = append(lines, "<ca>")
+	for _, certificate := range certificates {
+		lines = append(lines,
+			"-----BEGIN CERTIFICATE-----",
+			certificate,
+			"-----END CERTIFICATE-----",
+		)
 	}
+	lines = append(lines, "</ca>")
+	return lines
 }
 
 func WrapOpenvpnCert(clientCertificate string) (lines []string) {

--- a/internal/provider/utils/openvpn_test.go
+++ b/internal/provider/utils/openvpn_test.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrapOpenvpnCAs(t *testing.T) {
+	t.Parallel()
+
+	lines := WrapOpenvpnCAs([]string{"cert1", "cert2"})
+
+	assert.Equal(t, []string{
+		"<ca>",
+		"-----BEGIN CERTIFICATE-----",
+		"cert1",
+		"-----END CERTIFICATE-----",
+		"-----BEGIN CERTIFICATE-----",
+		"cert2",
+		"-----END CERTIFICATE-----",
+		"</ca>",
+	}, lines)
+}
+
+func TestWrapOpenvpnCA(t *testing.T) {
+	t.Parallel()
+
+	lines := WrapOpenvpnCA("cert1")
+
+	assert.Equal(t, []string{
+		"<ca>",
+		"-----BEGIN CERTIFICATE-----",
+		"cert1",
+		"-----END CERTIFICATE-----",
+		"</ca>",
+	}, lines)
+}


### PR DESCRIPTION
# Description

Fixes OpenVPN emission so it can handle two or more CA certificates

# Issue

Fixes #3224, #3256 

# Assertions

* [x] I am aware that we do not accept manual changes to the servers.json file <!-- If this is your goal, please consult https://github.com/qdm12/gluetun-wiki/blob/main/setup/servers.md#update-using-the-command-line -->
* [x] I am aware that any changes to settings should be reflected in the [wiki](https://github.com/qdm12/gluetun-wiki/)
