### PR TITLE
fix(vyprvpn/updater): update broken OpenVPN config ZIP URL

### DIFF
--- a/internal/provider/vyprvpn/updater/servers.go
+++ b/internal/provider/vyprvpn/updater/servers.go
@@ -14,7 +14,7 @@ import (
 func (u *Updater) FetchServers(ctx context.Context, minServers int) (
 	servers []models.Server, err error,
 ) {
-	const url = "https://support.vyprvpn.com/hc/article_attachments/360052617332/Vypr_OpenVPN_20200320.zip"
+	const url = "https://support.vyprvpn.com/hc/article_attachments/44585865394189"
 	contents, err := u.unzipper.FetchAndExtract(ctx, url)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

The VyprVPN server updater hardcodes a broken URL to download OpenVPN configuration files:
https://support.vyprvpn.com/hc/article_attachments/360052617332/Vypr_OpenVPN_20200320.zip

This fix updates the link. 

# Issue

Fix https://github.com/qdm12/gluetun/issues/3263

# Assertions

* [x] I am aware that we do not accept manual changes to the servers.json file <!-- If this is your goal, please consult https://github.com/qdm12/gluetun-wiki/blob/main/setup/servers.md#update-using-the-command-line -->
* [x] I am aware that any changes to settings should be reflected in the [wiki](https://github.com/qdm12/gluetun-wiki/)
