### PR TITLE
fix(wireguard): support IPv6 address formatting from config files

### DIFF
--- a/internal/configuration/sources/files/wireguard.go
+++ b/internal/configuration/sources/files/wireguard.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"gopkg.in/ini.v1"
 )
@@ -85,7 +86,10 @@ func parseWireguardPeerSection(peerSection *ini.Section) (
 		host, port, err := net.SplitHostPort(*endpoint)
 		if err == nil {
 			endpointIP = &host
-			endpointPort = &port
+			// IPv6 hosts contain colons; port is managed by the provider for those
+			if !strings.Contains(host, ":") {
+				endpointPort = &port
+			}
 		} else {
 			endpointIP = endpoint
 		}

--- a/internal/configuration/sources/files/wireguard_test.go
+++ b/internal/configuration/sources/files/wireguard_test.go
@@ -182,8 +182,7 @@ Endpoint = 1.2.3.4:51820`,
 		"ipv6_endpoint": {
 			iniData: `[Peer]
 Endpoint = [2a02:bbbb:aaaa:8075::10]:51820`,
-			endpointIP:   ptrTo("2a02:bbbb:aaaa:8075::10"),
-			endpointPort: ptrTo("51820"),
+			endpointIP: ptrTo("2a02:bbbb:aaaa:8075::10"),
 		},
 	}
 


### PR DESCRIPTION
# Description

<!-- Please describe the reason for the changes being proposed. -->
Wireguard setup with an ipv6 address was failing to parse

# Issue

<!-- Please link to the issue(s) this change relates to. -->
ipv6 addresses in wireguard are referenced like this, the code can not parse the [] in the text
```
[Peer]
Endpoint = [2222:6666:eeee:8888::10]:51820
```
erroneously, the logs point to this issue but it is unrelated to the ipv6 parsing https://github.com/qdm12/gluetun/issues/788

# Assertions

* [x] I am aware that we do not accept manual changes to the servers.json file <!-- If this is your goal, please consult https://github.com/qdm12/gluetun-wiki/blob/main/setup/servers.md#update-using-the-command-line -->
* [x] I am aware that any changes to settings should be reflected in the [wiki](https://github.com/qdm12/gluetun-wiki/)
