### PR TITLE
fix(protonvpn): use legacy API for updater authentication

### DIFF
--- a/internal/provider/protonvpn/updater/api.go
+++ b/internal/provider/protonvpn/updater/api.go
@@ -18,9 +18,8 @@ import (
 	srp "github.com/ProtonMail/go-srp"
 )
 
-// apiClient is a minimal Proton v4 API client which can handle all the
-// oddities of Proton's authentication flow they want to keep hidden
-// from the public.
+// apiClient is a minimal Proton API client using the legacy api.protonvpn.ch
+// endpoint which supports direct SRP auth without session/CAPTCHA requirements.
 type apiClient struct {
 	apiURLBase string
 	httpClient *http.Client
@@ -29,16 +28,12 @@ type apiClient struct {
 	generator  *rand.ChaCha8
 }
 
-// newAPIClient returns an [apiClient] with sane defaults matching Proton's
-// insane expectations.
+// newAPIClient returns an [apiClient] with sane defaults.
 func newAPIClient(ctx context.Context, httpClient *http.Client) (client *apiClient, err error) {
 	var seed [32]byte
 	_, _ = crand.Read(seed[:])
 	generator := rand.NewChaCha8(seed)
 
-	// Pick a random user agent from this list. Because I'm not going to tell
-	// Proton shit on where all these funny requests are coming from, given their
-	// unhelpfulness in figuring out their authentication flow.
 	userAgents := [...]string{
 		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:143.0) Gecko/20100101 Firefox/143.0",
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:143.0) Gecko/20100101 Firefox/143.0",
@@ -52,7 +47,7 @@ func newAPIClient(ctx context.Context, httpClient *http.Client) (client *apiClie
 	}
 
 	return &apiClient{
-		apiURLBase: "https://account.proton.me/api",
+		apiURLBase: "https://api.protonvpn.ch",
 		httpClient: httpClient,
 		appVersion: appVersion,
 		userAgent:  userAgent,
@@ -62,63 +57,42 @@ func newAPIClient(ctx context.Context, httpClient *http.Client) (client *apiClie
 
 var ErrCodeNotSuccess = errors.New("response code is not success")
 
-// setHeaders sets the minimal necessary headers for Proton API requests
-// to succeed without being blocked by their "security" measures.
-// See for example [getMostRecentStableTag] on how the app version must
-// be set to a recent version or they block your request. "SeCuRiTy"...
-func (c *apiClient) setHeaders(request *http.Request, cookie cookie) {
-	request.Header.Set("Cookie", cookie.String())
+// setHeaders sets the minimal necessary headers for Proton API requests.
+func (c *apiClient) setHeaders(request *http.Request, authToken string) {
 	request.Header.Set("User-Agent", c.userAgent)
 	request.Header.Set("x-pm-appversion", c.appVersion)
 	request.Header.Set("x-pm-locale", "en_US")
-	request.Header.Set("x-pm-uid", cookie.uid)
+	if authToken != "" {
+		request.Header.Set("Authorization", "Bearer "+authToken)
+	}
 }
 
-// authenticate performs the full Proton authentication flow
-// to obtain an authenticated cookie (uid, token and session ID).
+// authenticate performs direct SRP authentication against the legacy Proton VPN API
+// and returns a bearer token for subsequent requests.
 func (c *apiClient) authenticate(ctx context.Context, email, password string,
 ) (authCookie cookie, err error) {
-	sessionID, err := c.getSessionID(ctx)
-	if err != nil {
-		return cookie{}, fmt.Errorf("getting session ID: %w", err)
-	}
-
-	tokenType, accessToken, refreshToken, uid, err := c.getUnauthSession(ctx, sessionID)
-	if err != nil {
-		return cookie{}, fmt.Errorf("getting unauthenticated session data: %w", err)
-	}
-
-	cookieToken, err := c.cookieToken(ctx, sessionID, tokenType, accessToken, refreshToken, uid)
-	if err != nil {
-		return cookie{}, fmt.Errorf("getting cookie token: %w", err)
-	}
-
-	unauthCookie := cookie{
-		uid:       uid,
-		token:     cookieToken,
-		sessionID: sessionID,
-	}
+	// Step 1: Get SRP auth info (no session needed with legacy API)
 	username, modulusPGPClearSigned, serverEphemeralBase64, saltBase64,
-		srpSessionHex, version, err := c.authInfo(ctx, email, unauthCookie)
+		srpSessionHex, version, err := c.authInfo(ctx, email)
 	if err != nil {
 		return cookie{}, fmt.Errorf("getting auth information: %w", err)
 	}
 
-	// Prepare SRP proof generator using Proton's official SRP parameters and hashing.
+	// Step 2: Prepare SRP proof
 	srpAuth, err := srp.NewAuth(version, username, []byte(password),
 		saltBase64, modulusPGPClearSigned, serverEphemeralBase64)
 	if err != nil {
 		return cookie{}, fmt.Errorf("initializing SRP auth: %w", err)
 	}
 
-	// Generate SRP proofs (A, M1) with the usual 2048-bit modulus.
 	const modulusBits = 2048
 	proofs, err := srpAuth.GenerateProofs(modulusBits)
 	if err != nil {
 		return cookie{}, fmt.Errorf("generating SRP proofs: %w", err)
 	}
 
-	authCookie, err = c.auth(ctx, unauthCookie, email, srpSessionHex, proofs)
+	// Step 3: Submit SRP proof and get access token
+	authCookie, err = c.auth(ctx, email, srpSessionHex, proofs)
 	if err != nil {
 		return cookie{}, fmt.Errorf("authentifying: %w", err)
 	}
@@ -126,192 +100,17 @@ func (c *apiClient) authenticate(ctx context.Context, email, password string,
 	return authCookie, nil
 }
 
-var ErrSessionIDNotFound = errors.New("session ID not found in cookies")
-
-func (c *apiClient) getSessionID(ctx context.Context) (sessionID string, err error) {
-	const url = "https://account.proton.me/vpn"
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return "", fmt.Errorf("creating request: %w", err)
-	}
-
-	response, err := c.httpClient.Do(request)
-	if err != nil {
-		return "", err
-	}
-	err = response.Body.Close()
-	if err != nil {
-		return "", fmt.Errorf("closing response body: %w", err)
-	}
-
-	for _, cookie := range response.Cookies() {
-		if cookie.Name == "Session-Id" {
-			return cookie.Value, nil
-		}
-	}
-
-	return "", fmt.Errorf("%w", ErrSessionIDNotFound)
-}
-
-var ErrDataFieldMissing = errors.New("data field missing in response")
-
-func (c *apiClient) getUnauthSession(ctx context.Context, sessionID string) (
-	tokenType, accessToken, refreshToken, uid string, err error,
-) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURLBase+"/auth/v4/sessions", nil)
-	if err != nil {
-		return "", "", "", "", fmt.Errorf("creating request: %w", err)
-	}
-	unauthCookie := cookie{
-		sessionID: sessionID,
-	}
-	c.setHeaders(request, unauthCookie)
-
-	response, err := c.httpClient.Do(request)
-	if err != nil {
-		return "", "", "", "", err
-	}
-	defer response.Body.Close()
-
-	responseBody, err := io.ReadAll(response.Body)
-	if err != nil {
-		return "", "", "", "", fmt.Errorf("reading response body: %w", err)
-	} else if response.StatusCode != http.StatusOK {
-		return "", "", "", "", buildError(response.StatusCode, responseBody)
-	}
-
-	var data struct {
-		Code         uint     `json:"Code"`         // 1000 on success
-		AccessToken  string   `json:"AccessToken"`  // 32-chars lowercase and digits
-		RefreshToken string   `json:"RefreshToken"` // 32-chars lowercase and digits
-		TokenType    string   `json:"TokenType"`    // "Bearer"
-		Scopes       []string `json:"Scopes"`       // should be [] for our usage
-		UID          string   `json:"UID"`          // 32-chars lowercase and digits
-		LocalID      uint     `json:"LocalID"`      // 0 in my case
-	}
-
-	err = json.Unmarshal(responseBody, &data)
-	if err != nil {
-		return "", "", "", "", fmt.Errorf("decoding response body: %w", err)
-	}
-
-	const successCode = 1000
-	switch {
-	case data.Code != successCode:
-		return "", "", "", "", fmt.Errorf("%w: expected %d got %d",
-			ErrCodeNotSuccess, successCode, data.Code)
-	case data.AccessToken == "":
-		return "", "", "", "", fmt.Errorf("%w: access token is empty", ErrDataFieldMissing)
-	case data.RefreshToken == "":
-		return "", "", "", "", fmt.Errorf("%w: refresh token is empty", ErrDataFieldMissing)
-	case data.TokenType == "":
-		return "", "", "", "", fmt.Errorf("%w: token type is empty", ErrDataFieldMissing)
-	case data.UID == "":
-		return "", "", "", "", fmt.Errorf("%w: UID is empty", ErrDataFieldMissing)
-	}
-	// Ignore Scopes and LocalID fields, we don't use them.
-
-	return data.TokenType, data.AccessToken, data.RefreshToken, data.UID, nil
-}
-
-var ErrUIDMismatch = errors.New("UID in response does not match request UID")
-
-func (c *apiClient) cookieToken(ctx context.Context, sessionID, tokenType, accessToken,
-	refreshToken, uid string,
-) (cookieToken string, err error) {
-	type requestBodySchema struct {
-		GrantType    string `json:"GrantType"`    // "refresh_token"
-		Persistent   uint   `json:"Persistent"`   // 0
-		RedirectURI  string `json:"RedirectURI"`  // "https://protonmail.com"
-		RefreshToken string `json:"RefreshToken"` // 32-chars lowercase and digits
-		ResponseType string `json:"ResponseType"` // "token"
-		State        string `json:"State"`        // 24-chars letters and digits
-		UID          string `json:"UID"`          // 32-chars lowercase and digits
-	}
-	requestBody := requestBodySchema{
-		GrantType:    "refresh_token",
-		Persistent:   0,
-		RedirectURI:  "https://protonmail.com",
-		RefreshToken: refreshToken,
-		ResponseType: "token",
-		State:        generateLettersDigits(c.generator, 24), //nolint:mnd
-		UID:          uid,
-	}
-
-	buffer := bytes.NewBuffer(nil)
-	encoder := json.NewEncoder(buffer)
-	if err := encoder.Encode(requestBody); err != nil {
-		return "", fmt.Errorf("encoding request body: %w", err)
-	}
-
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURLBase+"/core/v4/auth/cookies", buffer)
-	if err != nil {
-		return "", fmt.Errorf("creating request: %w", err)
-	}
-	unauthCookie := cookie{
-		uid:       uid,
-		sessionID: sessionID,
-	}
-	c.setHeaders(request, unauthCookie)
-	request.Header.Set("Authorization", tokenType+" "+accessToken)
-
-	response, err := c.httpClient.Do(request)
-	if err != nil {
-		return "", err
-	}
-	defer response.Body.Close()
-
-	responseBody, err := io.ReadAll(response.Body)
-	if err != nil {
-		return "", fmt.Errorf("reading response body: %w", err)
-	} else if response.StatusCode != http.StatusOK {
-		return "", buildError(response.StatusCode, responseBody)
-	}
-
-	var cookies struct {
-		Code           uint   `json:"Code"`           // 1000 on success
-		UID            string `json:"UID"`            // should match request UID
-		LocalID        uint   `json:"LocalID"`        // 0
-		RefreshCounter uint   `json:"RefreshCounter"` // 1
-	}
-	err = json.Unmarshal(responseBody, &cookies)
-	if err != nil {
-		return "", fmt.Errorf("decoding response body: %w", err)
-	}
-
-	const successCode = 1000
-	switch {
-	case cookies.Code != successCode:
-		return "", fmt.Errorf("%w: expected %d got %d",
-			ErrCodeNotSuccess, successCode, cookies.Code)
-	case cookies.UID != requestBody.UID:
-		return "", fmt.Errorf("%w: expected %s got %s",
-			ErrUIDMismatch, requestBody.UID, cookies.UID)
-	}
-	// Ignore LocalID and RefreshCounter fields, we don't use them.
-
-	for _, cookie := range response.Cookies() {
-		if cookie.Name == "AUTH-"+uid {
-			return cookie.Value, nil
-		}
-	}
-
-	return "", fmt.Errorf("%w", ErrAuthCookieNotFound)
-}
-
 var ErrUsernameDoesNotExist = errors.New("username does not exist")
 
-// authInfo fetches SRP parameters for the account.
-func (c *apiClient) authInfo(ctx context.Context, email string, unauthCookie cookie) (
+// authInfo fetches SRP parameters for the account using the legacy API.
+func (c *apiClient) authInfo(ctx context.Context, email string) (
 	username, modulusPGPClearSigned, serverEphemeralBase64, saltBase64, srpSessionHex string,
 	version int, err error,
 ) {
 	type requestBodySchema struct {
-		Intent   string `json:"Intent"` // "Proton"
 		Username string `json:"Username"`
 	}
 	requestBody := requestBodySchema{
-		Intent:   "Proton",
 		Username: email,
 	}
 
@@ -321,11 +120,12 @@ func (c *apiClient) authInfo(ctx context.Context, email string, unauthCookie coo
 		return "", "", "", "", "", 0, fmt.Errorf("encoding request body: %w", err)
 	}
 
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURLBase+"/core/v4/auth/info", buffer)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURLBase+"/auth/info", buffer)
 	if err != nil {
 		return "", "", "", "", "", 0, fmt.Errorf("creating request: %w", err)
 	}
-	c.setHeaders(request, unauthCookie)
+	request.Header.Set("Content-Type", "application/json")
+	c.setHeaders(request, "")
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {
@@ -341,13 +141,13 @@ func (c *apiClient) authInfo(ctx context.Context, email string, unauthCookie coo
 	}
 
 	var info struct {
-		Code            uint   `json:"Code"`              // 1000 on success
-		Modulus         string `json:"Modulus"`           // PGP clearsigned modulus string
-		ServerEphemeral string `json:"ServerEphemeral"`   // base64
-		Version         *uint  `json:"Version,omitempty"` // 4 as of 2025-10-26
-		Salt            string `json:"Salt"`              // base64
-		SRPSession      string `json:"SRPSession"`        // hexadecimal
-		Username        string `json:"Username"`          // user without @domain.com. Mine has its first letter capitalized.
+		Code            uint   `json:"Code"`
+		Modulus         string `json:"Modulus"`
+		ServerEphemeral string `json:"ServerEphemeral"`
+		Version         *uint  `json:"Version,omitempty"`
+		Salt            string `json:"Salt"`
+		SRPSession      string `json:"SRPSession"`
+		Username        string `json:"Username"`
 	}
 	err = json.Unmarshal(responseBody, &info)
 	if err != nil {
@@ -367,58 +167,46 @@ func (c *apiClient) authInfo(ctx context.Context, email string, unauthCookie coo
 		return "", "", "", "", "", 0, fmt.Errorf("%w (salt data field is empty)", ErrUsernameDoesNotExist)
 	case info.SRPSession == "":
 		return "", "", "", "", "", 0, fmt.Errorf("%w: SRP session is empty", ErrDataFieldMissing)
-	case info.Username == "":
-		return "", "", "", "", "", 0, fmt.Errorf("%w: username is empty", ErrDataFieldMissing)
 	case info.Version == nil:
 		return "", "", "", "", "", 0, fmt.Errorf("%w: version is missing", ErrDataFieldMissing)
 	}
 
+	// Username may be nil/empty in legacy API response, use email as fallback
+	username = info.Username
+	if username == "" {
+		username = email
+	}
+
 	version = int(*info.Version) //nolint:gosec
-	return info.Username, info.Modulus, info.ServerEphemeral, info.Salt,
+	return username, info.Modulus, info.ServerEphemeral, info.Salt,
 		info.SRPSession, version, nil
 }
 
-type cookie struct {
-	uid       string
-	token     string
-	sessionID string
-}
+var ErrDataFieldMissing = errors.New("data field missing in response")
 
-func (c *cookie) String() string {
-	s := ""
-	if c.token != "" {
-		s += fmt.Sprintf("AUTH-%s=%s; ", c.uid, c.token)
-	}
-	if c.sessionID != "" {
-		s += fmt.Sprintf("Session-Id=%s; ", c.sessionID)
-	}
-	if c.token != "" {
-		s += "Tag=default; iaas=W10; Domain=proton.me; Feature=VPNDashboard:A"
-	}
-	return s
+type cookie struct {
+	uid   string
+	token string
 }
 
 var (
-	// ErrServerProofNotValid indicates the M2 from the server didn't match the expected proof.
 	ErrServerProofNotValid = errors.New("server proof from server is not valid")
 	ErrVPNScopeNotFound    = errors.New("VPN scope not found in scopes")
 	ErrTwoFANotSupported   = errors.New("two factor authentication not supported in this client")
-	ErrAuthCookieNotFound  = errors.New("auth cookie not found")
 )
 
-// auth performs the SRP proof submission (and optionally TOTP) to obtain tokens.
-func (c *apiClient) auth(ctx context.Context, unauthCookie cookie,
+// auth performs the SRP proof submission to obtain an access token.
+func (c *apiClient) auth(ctx context.Context,
 	username, srpSession string, proofs *srp.Proofs,
 ) (authCookie cookie, err error) {
 	clientEphemeral := base64.StdEncoding.EncodeToString(proofs.ClientEphemeral)
 	clientProof := base64.StdEncoding.EncodeToString(proofs.ClientProof)
 
 	type requestBodySchema struct {
-		ClientEphemeral string            `json:"ClientEphemeral"`   // base64(A)
-		ClientProof     string            `json:"ClientProof"`       // base64(M1)
-		Payload         map[string]string `json:"Payload,omitempty"` // not sure
-		SRPSession      string            `json:"SRPSession"`        // hexadecimal
-		Username        string            `json:"Username"`          // user@protonmail.com
+		ClientEphemeral string `json:"ClientEphemeral"`
+		ClientProof     string `json:"ClientProof"`
+		SRPSession      string `json:"SRPSession"`
+		Username        string `json:"Username"`
 	}
 	requestBody := requestBodySchema{
 		ClientEphemeral: clientEphemeral,
@@ -433,11 +221,12 @@ func (c *apiClient) auth(ctx context.Context, unauthCookie cookie,
 		return cookie{}, fmt.Errorf("encoding request body: %w", err)
 	}
 
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURLBase+"/core/v4/auth", buffer)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURLBase+"/auth", buffer)
 	if err != nil {
 		return cookie{}, fmt.Errorf("creating request: %w", err)
 	}
-	c.setHeaders(request, unauthCookie)
+	request.Header.Set("Content-Type", "application/json")
+	c.setHeaders(request, "")
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {
@@ -452,35 +241,14 @@ func (c *apiClient) auth(ctx context.Context, unauthCookie cookie,
 		return cookie{}, buildError(response.StatusCode, responseBody)
 	}
 
-	type twoFAStatus uint
-	//nolint:unused
-	const (
-		twoFADisabled twoFAStatus = iota
-		twoFAHasTOTP
-		twoFAHasFIDO2
-		twoFAHasFIDO2AndTOTP
-	)
-	type twoFAInfo struct {
-		Enabled twoFAStatus `json:"Enabled"`
-		FIDO2   struct {
-			AuthenticationOptions any   `json:"AuthenticationOptions"`
-			RegisteredKeys        []any `json:"RegisteredKeys"`
-		} `json:"FIDO2"`
-		TOTP uint `json:"TOTP"`
-	}
-
 	var auth struct {
-		Code              uint      `json:"Code"`         // 1000 on success
-		LocalID           uint      `json:"LocalID"`      // 7 in my case
-		Scopes            []string  `json:"Scopes"`       // this should contain "vpn". Same as `Scope` field value.
-		UID               string    `json:"UID"`          // same as `Uid` field value
-		UserID            string    `json:"UserID"`       // base64
-		EventID           string    `json:"EventID"`      // base64
-		PasswordMode      uint      `json:"PasswordMode"` // 1 in my case
-		ServerProof       string    `json:"ServerProof"`  // base64(M2)
-		TwoFactor         uint      `json:"TwoFactor"`    // 0 if 2FA not required
-		TwoFA             twoFAInfo `json:"2FA"`
-		TemporaryPassword uint      `json:"TemporaryPassword"` // 0 in my case
+		Code         uint     `json:"Code"`
+		UID          string   `json:"UID"`
+		AccessToken  string   `json:"AccessToken"`
+		TokenType    string   `json:"TokenType"`
+		Scopes       []string `json:"Scopes"`
+		ServerProof  string   `json:"ServerProof"`
+		TwoFactor    uint     `json:"TwoFactor"`
 	}
 
 	err = json.Unmarshal(responseBody, &auth)
@@ -502,45 +270,16 @@ func (c *apiClient) auth(ctx context.Context, unauthCookie cookie,
 	case auth.Code != successCode:
 		return cookie{}, fmt.Errorf("%w: expected %d got %d",
 			ErrCodeNotSuccess, successCode, auth.Code)
-	case auth.UID != unauthCookie.uid:
-		return cookie{}, fmt.Errorf("%w: expected %s got %s",
-			ErrUIDMismatch, unauthCookie.uid, auth.UID)
 	case auth.TwoFactor != 0:
 		return cookie{}, fmt.Errorf("%w", ErrTwoFANotSupported)
 	case !slices.Contains(auth.Scopes, "vpn"):
 		return cookie{}, fmt.Errorf("%w: in %v", ErrVPNScopeNotFound, auth.Scopes)
 	}
 
-	for _, setCookieHeader := range response.Header.Values("Set-Cookie") {
-		parts := strings.Split(setCookieHeader, ";")
-		for _, part := range parts {
-			if strings.HasPrefix(part, "AUTH-"+unauthCookie.uid+"=") {
-				authCookie = unauthCookie
-				authCookie.token = strings.TrimPrefix(part, "AUTH-"+unauthCookie.uid+"=")
-				return authCookie, nil
-			}
-		}
-	}
-
-	return cookie{}, fmt.Errorf("%w: in HTTP headers %s",
-		ErrAuthCookieNotFound, httpHeadersToString(response.Header))
-}
-
-// generateLettersDigits mimicing Proton's own random string generator:
-// https://github.com/ProtonMail/WebClients/blob/e4d7e4ab9babe15b79a131960185f9f8275512cd/packages/utils/generateLettersDigits.ts
-func generateLettersDigits(rng *rand.ChaCha8, length uint) string {
-	const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
-	return generateFromCharset(rng, length, charset)
-}
-
-func generateFromCharset(rng *rand.ChaCha8, length uint, charset string) string {
-	result := make([]byte, length)
-	randomBytes := make([]byte, length)
-	_, _ = rng.Read(randomBytes)
-	for i := range length {
-		result[i] = charset[int(randomBytes[i])%len(charset)]
-	}
-	return string(result)
+	return cookie{
+		uid:   auth.UID,
+		token: auth.AccessToken,
+	}, nil
 }
 
 func httpHeadersToString(headers http.Header) string {
@@ -580,15 +319,15 @@ type physicalServer struct {
 	X25519PublicKey string     `json:"X25519PublicKey"`
 }
 
-func (c *apiClient) fetchServers(ctx context.Context, cookie cookie) (
+func (c *apiClient) fetchServers(ctx context.Context, authCookie cookie) (
 	data apiData, err error,
 ) {
-	const url = "https://account.proton.me/api/vpn/logicals"
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apiURLBase+"/vpn/logicals", nil)
 	if err != nil {
 		return data, err
 	}
-	c.setHeaders(request, cookie)
+	c.setHeaders(request, authCookie.token)
+	request.Header.Set("x-pm-uid", authCookie.uid)
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {

--- a/internal/provider/protonvpn/updater/version.go
+++ b/internal/provider/protonvpn/updater/version.go
@@ -4,68 +4,51 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"regexp"
 	"strings"
-	"time"
 )
 
-// getMostRecentStableTag finds the most recent proton-account stable tag version,
+// getMostRecentStableTag finds the latest proton-vpn-gtk-app semver tag,
 // in order to use it in the x-pm-appversion http request header. Because if we do
 // fall behind on versioning, Proton doesn't like it because they like to create
 // complications where there is no need for it. Hence this function.
 func getMostRecentStableTag(ctx context.Context, client *http.Client) (version string, err error) {
-	page := 1
-	regexVersion := regexp.MustCompile(`^proton-account@(\d+\.\d+\.\d+\.\d+)$`)
-	for ctx.Err() == nil {
-		// Define a timeout since the default client has a large timeout and we don't
-		// want to wait too long.
-		const timeout = 5 * time.Second
-		ctx, cancel := context.WithTimeout(ctx, timeout)
-		defer cancel()
+	const url = "https://api.github.com/repos/ProtonVPN/proton-vpn-gtk-app/tags?per_page=30"
 
-		url := "https://api.github.com/repos/ProtonMail/WebClients/tags?per_page=30&page=" + fmt.Sprint(page)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	request.Header.Set("Accept", "application/vnd.github.v3+json")
 
-		request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-		if err != nil {
-			return "", fmt.Errorf("creating request: %w", err)
-		}
-		request.Header.Set("Accept", "application/vnd.github.v3+json")
+	response, err := client.Do(request)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
 
-		response, err := client.Do(request)
-		if err != nil {
-			return "", err
-		}
-		defer response.Body.Close()
-
-		data, err := io.ReadAll(response.Body)
-		if err != nil {
-			return "", fmt.Errorf("reading response body: %w", err)
-		}
-
-		if response.StatusCode != http.StatusOK {
-			return "", fmt.Errorf("%w: %s: %s", ErrHTTPStatusCodeNotOK, response.Status, data)
-		}
-
-		var tags []struct {
-			Name string `json:"name"`
-		}
-		err = json.Unmarshal(data, &tags)
-		if err != nil {
-			return "", fmt.Errorf("decoding JSON response: %w", err)
-		}
-
-		for _, tag := range tags {
-			if !regexVersion.MatchString(tag.Name) {
-				continue
-			}
-			version := "web-account@" + strings.TrimPrefix(tag.Name, "proton-account@")
-			return version, nil
-		}
-
-		page++
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w: %s", ErrHTTPStatusCodeNotOK, response.Status)
 	}
 
-	return "", fmt.Errorf("%w (queried %d pages)", context.Canceled, page)
+	decoder := json.NewDecoder(response.Body)
+	var data []struct {
+		Name string `json:"name"`
+	}
+	err = decoder.Decode(&data)
+	if err != nil {
+		return "", fmt.Errorf("decoding JSON response: %w", err)
+	}
+
+	// Find the first valid semver tag (tags are returned newest first by GitHub)
+	regexVersion := regexp.MustCompile(`^v(\d+\.\d+\.\d+)$`)
+	for _, tag := range data {
+		if m := regexVersion.FindStringSubmatch(tag.Name); m != nil {
+			version = "linux-vpn@" + strings.TrimPrefix(tag.Name, "v")
+			return version, nil
+		}
+	}
+
+	return "", fmt.Errorf("no valid semver tag found in proton-vpn-gtk-app tags")
 }


### PR DESCRIPTION
## Summary

  - Proton's `account.proton.me` API now requires a session/CAPTCHA flow that blocks automated access from     
  server environments (`POST /auth/v4/sessions` returns code 8004 "Operation not allowed")
  - Switch the ProtonVPN updater to use the legacy `api.protonvpn.ch` endpoint which supports direct SRP       
  authentication without the session dance                                                                     
  - Update `version.go` to fetch app version tags from `ProtonVPN/proton-vpn-gtk-app` instead of
  `ProtonMail/WebClients`, as `proton-account` tags are no longer published there                              
                                                                                                             
  ## Context                                                                                                   
                                                                                                             
  When running `gluetun update -maintainer -all` with ProtonVPN credentials, the updater fails at the
  unauthenticated session creation step:

  ERROR getting protonvpn servers: authentifying with Proton: getting unauthenticated session data:            
  HTTP status code not OK: Unprocessable Entity: Operation not allowed (code 8004 with details: )
                                                                                                               
  This happens because Proton now enforces human verification (CAPTCHA) on the                               
  `account.proton.me/api/auth/v4/sessions` endpoint for programmatic requests. The legacy `api.protonvpn.ch`   
  endpoint still accepts direct SRP auth (`/auth/info` + `/auth`) without requiring a session, so the fix
  switches to that flow.                                                                                       
                                                                                                             
  The `version.go` change is related: `ProtonMail/WebClients` no longer publishes `proton-account@` tags (the  
  latest tags are `proton-vpn-settings@`), causing the app version lookup to fail. Switching to
  `ProtonVPN/proton-vpn-gtk-app` tags and using `linux-vpn@` as the app version prefix resolves this. (Note:   
  the `protonvpn-more-servers` branch already has a similar version.go fix.)                                 

  ## Test plan

  - [x] Tested with valid ProtonVPN credentials — successfully authenticates and fetches 834 servers           
  - [x] Verified the legacy API returns the same `LogicalServers` data structure
  - [x] Confirmed disabled servers (status 0) are still correctly skipped