### PR TITLE
fix handshake window failure for openvpn

### DIFF
--- a/internal/provider/custom/openvpnconf.go
+++ b/internal/provider/custom/openvpnconf.go
@@ -76,7 +76,7 @@ func modifyConfig(lines []string, connection models.Connection,
 	modified = append(modified, "pull-filter ignore \"auth-token\"") // prevent auth failed loop
 	modified = append(modified, "auth-retry nointeract")
 	modified = append(modified, "suppress-timestamps")
-	modified = append(modified, "handshake-window 10") // default is 60 seconds which is too long
+	modified = append(modified, "hand-window 10") // default is 60 seconds which is too long
 	if *settings.User != "" {
 		modified = append(modified, "auth-user-pass "+openvpn.AuthConf)
 	}

--- a/internal/provider/custom/openvpnconf_test.go
+++ b/internal/provider/custom/openvpnconf_test.go
@@ -62,7 +62,7 @@ func Test_modifyConfig(t *testing.T) {
 				"pull-filter ignore \"auth-token\"",
 				"auth-retry nointeract",
 				"suppress-timestamps",
-				"handshake-window 10",
+				"hand-window 10",
 				"auth-user-pass /etc/openvpn/auth.conf",
 				"verb 0",
 				"data-ciphers-fallback cipher",

--- a/internal/provider/utils/openvpn.go
+++ b/internal/provider/utils/openvpn.go
@@ -62,7 +62,7 @@ func OpenVPNConfig(provider OpenVPNProviderSettings,
 	lines.add("mute-replay-warnings")     // these are often ignored by some VPN providers
 	lines.add("auth-retry", "nointeract") // retry authenticating without interaction
 	lines.add("suppress-timestamps")      // do not log timestamps, the Gluetun logger takes care of it
-	lines.add("handshake-window", "10")   // default is 60 seconds which is too long
+	lines.add("hand-window", "10")   // default is 60 seconds which is too long
 	lines.add("dev", settings.Interface)
 	lines.add("verb", fmt.Sprint(*settings.Verbosity))
 	protocol := connection.Protocol


### PR DESCRIPTION
# Description

Fixes openvpn failing due to incorrectly using `handshake-window` arg instead of `hand-window` introduced in f615e3c (see https://openvpn.net/community-docs/community-articles/openvpn-2-5-manual.html#:~:text=the%20ca%20file.-,%2D%2Dhand%2Dwindow%20n,-Handshake%20Window%20%2D%2D%20the)

# Issue

https://github.com/qdm12/gluetun/issues/3306

# Assertions

* [x] I am aware that we do not accept manual changes to the servers.json file <!-- If this is your goal, please consult https://github.com/qdm12/gluetun-wiki/blob/main/setup/servers.md#update-using-the-command-line -->
* [x] I am aware that any changes to settings should be reflected in the [wiki](https://github.com/qdm12/gluetun-wiki/)
