### PR TITLE
fix(openvpn/extract): trim spaces in config lines before parsing

### DIFF
--- a/internal/openvpn/extract/extract.go
+++ b/internal/openvpn/extract/extract.go
@@ -53,6 +53,8 @@ func extractDataFromLines(lines []string) (
 func extractDataFromLine(line string) (
 	ip netip.Addr, port uint16, protocol string, err error,
 ) {
+	line = strings.TrimSpace(line)
+
 	switch {
 	case strings.HasPrefix(line, "proto "):
 		protocol, err = extractProto(line)

--- a/internal/openvpn/extract/extract_test.go
+++ b/internal/openvpn/extract/extract_test.go
@@ -62,6 +62,14 @@ func Test_extractDataFromLines(t *testing.T) {
 				Protocol: constants.UDP,
 			},
 		},
+		"leading_whitespace": {
+			lines: []string{"  proto tcp", "\tremote 1.2.3.4 443 tcp"},
+			connection: models.Connection{
+				IP:       netip.AddrFrom4([4]byte{1, 2, 3, 4}),
+				Port:     443,
+				Protocol: constants.TCP,
+			},
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
Small parser papercut fix for custom OpenVPN configs.

Repro:
```go
lines := []string{"  proto tcp", "\tremote 1.2.3.4 443 tcp"}
_, err := extractDataFromLines(lines) // before: remote line not found
```

OpenVPN itself accepts those indented directives, so Gluetun should read them too. Tiny but kinda annoying when a config is formatted that way.

Fixed by trimming each line before matching `proto`, `remote`, and `port`.

Checked:
```sh
go test ./internal/openvpn/extract -run Test_extractDataFromLines/leading_whitespace -count=1
go test ./internal/openvpn/extract
go build ./...
```

Related parsing area: #1986
