### PR TITLE
fix(providers/custom): use `proto tcp-client` instead of `proto tcp`

### DIFF
--- a/internal/provider/custom/openvpnconf.go
+++ b/internal/provider/custom/openvpnconf.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/qdm12/gluetun/internal/configuration/settings"
+	"github.com/qdm12/gluetun/internal/constants"
 	"github.com/qdm12/gluetun/internal/constants/openvpn"
 	"github.com/qdm12/gluetun/internal/models"
 	"github.com/qdm12/gluetun/internal/provider/utils"
@@ -65,7 +66,11 @@ func modifyConfig(lines []string, connection models.Connection,
 	}
 
 	// Add values
-	modified = append(modified, "proto "+connection.Protocol)
+	protocol := connection.Protocol
+	if protocol == constants.TCP {
+		protocol = "tcp-client"
+	}
+	modified = append(modified, "proto "+protocol)
 	modified = append(modified, fmt.Sprintf("remote %s %d", connection.IP, connection.Port))
 	modified = append(modified, "dev "+settings.Interface)
 	modified = append(modified, "mute-replay-warnings")


### PR DESCRIPTION
# Description

When using a custom OpenVPN config file (OPENVPN_CUSTOM_CONFIG) with a TCP connection, Gluetun fails with:

`ERROR [openvpn] --proto tcp is ambiguous in this context. Please specify --proto tcp-server or --proto tcp-client
ERROR [vpn] exit status 1`

modifyConfig in the custom provider always strips the proto line from the user's config file and rewrites it from connection.Protocol. The extractor normalizes tcp-client → constants.TCP ("tcp"), so the rewritten line becomes proto tcp — which OpenVPN 2.6 rejects.

This fix mirrors the exact same tcp → tcp-client translation already applied to internal/provider/utils/openvpn.go in commit 66b9f71, which fixed built-in providers but missed the custom provider path.

# Issue

Fixes #3302

# Assertions

* [x] I am aware that any changes to settings should be reflected in the [wiki](https://github.com/qdm12/gluetun-wiki/)
