### PR TITLE
fix(healthcheck): guard periodic checks against divide-by-zero when config is cleared

### DIFF
--- a/internal/healthcheck/checker.go
+++ b/internal/healthcheck/checker.go
@@ -159,6 +159,8 @@ func (c *Checker) Start(ctx context.Context) (runError <-chan error, err error) 
 func (c *Checker) Stop() error {
 	c.stop()
 	<-c.done
+	c.configMutex.Lock()
+	defer c.configMutex.Unlock()
 	c.tlsDialAddrs = nil
 	c.icmpTargetIPs = nil
 	c.smallCheckType = ""
@@ -170,6 +172,9 @@ func (c *Checker) smallPeriodicCheck(ctx context.Context) error {
 	icmpTargetIPs := make([]netip.Addr, len(c.icmpTargetIPs))
 	copy(icmpTargetIPs, c.icmpTargetIPs)
 	c.configMutex.Unlock()
+	if c.smallCheckType != smallCheckDNS && len(icmpTargetIPs) == 0 {
+		return nil
+	}
 	tryTimeouts := []time.Duration{
 		5 * time.Second,
 		5 * time.Second,
@@ -202,11 +207,18 @@ func (c *Checker) smallPeriodicCheck(ctx context.Context) error {
 }
 
 func (c *Checker) fullPeriodicCheck(ctx context.Context) error {
+	c.configMutex.Lock()
+	tlsDialAddrs := make([]string, len(c.tlsDialAddrs))
+	copy(tlsDialAddrs, c.tlsDialAddrs)
+	c.configMutex.Unlock()
+	if len(tlsDialAddrs) == 0 {
+		return nil
+	}
 	// 20s timeout in case the connection is under stress
 	// See https://github.com/qdm12/gluetun/issues/2270
 	tryTimeouts := []time.Duration{10 * time.Second, 15 * time.Second, 30 * time.Second}
 	check := func(ctx context.Context, try int) error {
-		tlsDialAddr := c.tlsDialAddrs[try%len(c.tlsDialAddrs)]
+		tlsDialAddr := tlsDialAddrs[try%len(tlsDialAddrs)]
 		return tcpTLSCheck(ctx, c.dialer, tlsDialAddr)
 	}
 	return withRetries(ctx, tryTimeouts, c.logger, "TCP+TLS dial", check)

--- a/internal/healthcheck/checker_test.go
+++ b/internal/healthcheck/checker_test.go
@@ -61,6 +61,20 @@ func Test_Checker_fullcheck(t *testing.T) {
 	})
 }
 
+func Test_Checker_periodicCheckEmptyTargets(t *testing.T) {
+	t.Parallel()
+
+	checker := &Checker{smallCheckType: smallCheckICMP}
+
+	err := checker.fullPeriodicCheck(context.Background())
+
+	assert.NoError(t, err)
+
+	err = checker.smallPeriodicCheck(context.Background())
+
+	assert.NoError(t, err)
+}
+
 func Test_makeAddressToDial(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# Description

The healthcheck goroutine can panic with `panic: runtime error: integer divide by zero` (stack at `internal/healthcheck/checker.go` in `fullPeriodicCheck`).

`fullPeriodicCheck` indexed the shared config slice directly with `c.tlsDialAddrs[try%len(c.tlsDialAddrs)]`. `Checker.Stop()` clears the config by setting `c.tlsDialAddrs = nil` (and `icmpTargetIPs` / `smallCheckType`) — but did so without holding `c.configMutex`. A `fullPeriodicCheck` still in flight during or just after `Stop()` then evaluates `try % len(c.tlsDialAddrs)` with `len == 0` and panics. It is also a data race: `fullPeriodicCheck` read `c.tlsDialAddrs` without the mutex while `Stop`/`SetConfig` wrote it. `smallPeriodicCheck` already copies `c.icmpTargetIPs` under the mutex, but its `icmpTargetIPs[try%len(icmpTargetIPs)]` had the same latent divide-by-zero when that copy is empty (`Stop` nils `icmpTargetIPs` too).

This change:

- `Stop()` now takes `c.configMutex` while clearing the config, synchronizing the clear with the readers.
- `fullPeriodicCheck()` copies `c.tlsDialAddrs` into a local slice under `c.configMutex` (mirroring `smallPeriodicCheck`) and returns early when the copy is empty — there is nothing to dial — instead of dividing by zero. The check closure indexes the local copy.
- `smallPeriodicCheck()` returns early when the (already-copied) ICMP target slice is empty and the check type is not DNS, so the copied-slice modulo cannot divide by zero either. The DNS-fallback path is unchanged.

Behavior is identical for a normally-running checker with non-empty config; the guards only affect the teardown / empty-config window.

Verified with `go test ./internal/healthcheck/...`, `go test -race ./internal/healthcheck/...`, `go build ./...`, and `gofmt -l` (clean). A regression test exercises the periodic checks with empty target slices and asserts they no longer panic.

# Issue

Closes #3398

# Assertions

* [x] I am aware that any changes to settings should be reflected in the [wiki](https://github.com/qdm12/gluetun-wiki/) — N/A, this change adds no settings and does not alter existing settings.
