### PR TITLE
fix(healthcheck): prevent race condition on the healthchecker

### DIFF
--- a/internal/healthcheck/checker.go
+++ b/internal/healthcheck/checker.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/netip"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/qdm12/gluetun/internal/healthcheck/dns"
@@ -24,7 +23,6 @@ type Checker struct {
 	icmpTargetIPs  []netip.Addr
 	smallCheckType string
 	startupOnFail  bool
-	configMutex    sync.Mutex
 
 	icmpNotPermitted *bool
 
@@ -55,8 +53,6 @@ func NewChecker(logger Logger) *Checker {
 func (c *Checker) SetConfig(tlsDialAddrs []string, icmpTargets []netip.Addr,
 	smallCheckType string, startupOnFail bool,
 ) {
-	c.configMutex.Lock()
-	defer c.configMutex.Unlock()
 	c.tlsDialAddrs = tlsDialAddrs
 	c.icmpTargetIPs = icmpTargets
 	c.smallCheckType = smallCheckType
@@ -166,10 +162,8 @@ func (c *Checker) Stop() error {
 }
 
 func (c *Checker) smallPeriodicCheck(ctx context.Context) error {
-	c.configMutex.Lock()
 	icmpTargetIPs := make([]netip.Addr, len(c.icmpTargetIPs))
 	copy(icmpTargetIPs, c.icmpTargetIPs)
-	c.configMutex.Unlock()
 	tryTimeouts := []time.Duration{
 		5 * time.Second,
 		5 * time.Second,

--- a/internal/healthcheck/checker.go
+++ b/internal/healthcheck/checker.go
@@ -159,8 +159,6 @@ func (c *Checker) Start(ctx context.Context) (runError <-chan error, err error) 
 func (c *Checker) Stop() error {
 	c.stop()
 	<-c.done
-	c.configMutex.Lock()
-	defer c.configMutex.Unlock()
 	c.tlsDialAddrs = nil
 	c.icmpTargetIPs = nil
 	c.smallCheckType = ""
@@ -172,9 +170,6 @@ func (c *Checker) smallPeriodicCheck(ctx context.Context) error {
 	icmpTargetIPs := make([]netip.Addr, len(c.icmpTargetIPs))
 	copy(icmpTargetIPs, c.icmpTargetIPs)
 	c.configMutex.Unlock()
-	if c.smallCheckType != smallCheckDNS && len(icmpTargetIPs) == 0 {
-		return nil
-	}
 	tryTimeouts := []time.Duration{
 		5 * time.Second,
 		5 * time.Second,
@@ -207,18 +202,11 @@ func (c *Checker) smallPeriodicCheck(ctx context.Context) error {
 }
 
 func (c *Checker) fullPeriodicCheck(ctx context.Context) error {
-	c.configMutex.Lock()
-	tlsDialAddrs := make([]string, len(c.tlsDialAddrs))
-	copy(tlsDialAddrs, c.tlsDialAddrs)
-	c.configMutex.Unlock()
-	if len(tlsDialAddrs) == 0 {
-		return nil
-	}
 	// 20s timeout in case the connection is under stress
 	// See https://github.com/qdm12/gluetun/issues/2270
 	tryTimeouts := []time.Duration{10 * time.Second, 15 * time.Second, 30 * time.Second}
 	check := func(ctx context.Context, try int) error {
-		tlsDialAddr := tlsDialAddrs[try%len(tlsDialAddrs)]
+		tlsDialAddr := c.tlsDialAddrs[try%len(c.tlsDialAddrs)]
 		return tcpTLSCheck(ctx, c.dialer, tlsDialAddr)
 	}
 	return withRetries(ctx, tryTimeouts, c.logger, "TCP+TLS dial", check)

--- a/internal/healthcheck/checker.go
+++ b/internal/healthcheck/checker.go
@@ -159,6 +159,8 @@ func (c *Checker) Start(ctx context.Context) (runError <-chan error, err error) 
 func (c *Checker) Stop() error {
 	c.stop()
 	<-c.done
+	c.configMutex.Lock()
+	defer c.configMutex.Unlock()
 	c.tlsDialAddrs = nil
 	c.icmpTargetIPs = nil
 	c.smallCheckType = ""
@@ -170,6 +172,9 @@ func (c *Checker) smallPeriodicCheck(ctx context.Context) error {
 	icmpTargetIPs := make([]netip.Addr, len(c.icmpTargetIPs))
 	copy(icmpTargetIPs, c.icmpTargetIPs)
 	c.configMutex.Unlock()
+	if c.smallCheckType != smallCheckDNS && len(icmpTargetIPs) == 0 {
+		return nil
+	}
 	tryTimeouts := []time.Duration{
 		5 * time.Second,
 		5 * time.Second,
@@ -202,11 +207,18 @@ func (c *Checker) smallPeriodicCheck(ctx context.Context) error {
 }
 
 func (c *Checker) fullPeriodicCheck(ctx context.Context) error {
+	c.configMutex.Lock()
+	tlsDialAddrs := make([]string, len(c.tlsDialAddrs))
+	copy(tlsDialAddrs, c.tlsDialAddrs)
+	c.configMutex.Unlock()
+	if len(tlsDialAddrs) == 0 {
+		return nil
+	}
 	// 20s timeout in case the connection is under stress
 	// See https://github.com/qdm12/gluetun/issues/2270
 	tryTimeouts := []time.Duration{10 * time.Second, 15 * time.Second, 30 * time.Second}
 	check := func(ctx context.Context, try int) error {
-		tlsDialAddr := c.tlsDialAddrs[try%len(c.tlsDialAddrs)]
+		tlsDialAddr := tlsDialAddrs[try%len(tlsDialAddrs)]
 		return tcpTLSCheck(ctx, c.dialer, tlsDialAddr)
 	}
 	return withRetries(ctx, tryTimeouts, c.logger, "TCP+TLS dial", check)

--- a/internal/healthcheck/checker_test.go
+++ b/internal/healthcheck/checker_test.go
@@ -61,20 +61,6 @@ func Test_Checker_fullcheck(t *testing.T) {
 	})
 }
 
-func Test_Checker_periodicCheckEmptyTargets(t *testing.T) {
-	t.Parallel()
-
-	checker := &Checker{smallCheckType: smallCheckICMP}
-
-	err := checker.fullPeriodicCheck(context.Background())
-
-	assert.NoError(t, err)
-
-	err = checker.smallPeriodicCheck(context.Background())
-
-	assert.NoError(t, err)
-}
-
 func Test_makeAddressToDial(t *testing.T) {
 	t.Parallel()
 

--- a/internal/healthcheck/checker_test.go
+++ b/internal/healthcheck/checker_test.go
@@ -61,6 +61,20 @@ func Test_Checker_fullcheck(t *testing.T) {
 	})
 }
 
+func Test_Checker_periodicCheckEmptyTargets(t *testing.T) {
+	t.Parallel()
+
+	checker := &Checker{smallCheckType: smallCheckICMP}
+
+	err := checker.fullPeriodicCheck(context.Background())
+
+	assert.NoError(t, err)
+
+	err = checker.smallPeriodicCheck(context.Background())
+
+	assert.NoError(t, err)
+}
+
 func Test_makeAddressToDial(t *testing.T) {
 	t.Parallel()
 

--- a/internal/vpn/loop.go
+++ b/internal/vpn/loop.go
@@ -45,6 +45,7 @@ type Loop struct {
 	start       <-chan struct{}
 	running     chan<- models.LoopStatus
 	userTrigger bool
+	healthDone  <-chan struct{}
 	// Internal constant values
 	backoffTime time.Duration
 }
@@ -69,6 +70,11 @@ func NewLoop(vpnSettings settings.VPN, ipv6SupportLevel netlink.IPv6SupportLevel
 
 	statusManager := loopstate.New(constants.Stopped, start, running, stop, stopped)
 	state := state.New(statusManager, vpnSettings)
+
+	// Initialize healthDone channel to a closed channel so that the first time
+	// we call <-l.healthDone it does not block
+	healthDone := make(chan struct{})
+	close(healthDone)
 
 	return &Loop{
 		statusManager:    statusManager,
@@ -98,6 +104,7 @@ func NewLoop(vpnSettings settings.VPN, ipv6SupportLevel netlink.IPv6SupportLevel
 		stop:             stop,
 		stopped:          stopped,
 		userTrigger:      true,
+		healthDone:       healthDone,
 		backoffTime:      defaultBackoffTime,
 	}
 }

--- a/internal/vpn/tunnelup.go
+++ b/internal/vpn/tunnelup.go
@@ -81,6 +81,7 @@ func (l *Loop) onTunnelUp(ctx, loopCtx context.Context, data tunnelUpData) {
 
 	_, _ = l.dnsLooper.ApplyStatus(ctx, constants.Running)
 
+	<-l.healthDone // make sure the health checker is stopped before restarting it
 	icmpTargetIPs := l.healthSettings.ICMPTargetIPs
 	if len(icmpTargetIPs) == 1 && icmpTargetIPs[0].IsUnspecified() {
 		icmpTargetIPs = []netip.Addr{data.serverIP}
@@ -104,7 +105,12 @@ func (l *Loop) onTunnelUp(ctx, loopCtx context.Context, data tunnelUpData) {
 	// Start collecting health errors asynchronously, since
 	// we should not wait for the code below to complete
 	// to start monitoring health and auto-healing.
-	go l.collectHealthErrors(ctx, loopCtx, healthErrCh)
+	// We keep track of when this goroutine is done with the healthDone
+	// channel to avoid a race condition where the health checker is stopped
+	// after being reconfigured and restarted, instead of before.
+	healthDone := make(chan struct{})
+	l.healthDone = healthDone
+	go l.collectHealthErrors(ctx, loopCtx, healthDone, healthErrCh)
 
 	err = l.publicip.RunOnce(ctx)
 	if err != nil {
@@ -140,7 +146,10 @@ func (l *Loop) onTunnelUp(ctx, loopCtx context.Context, data tunnelUpData) {
 	}
 }
 
-func (l *Loop) collectHealthErrors(ctx, loopCtx context.Context, healthErrCh <-chan error) {
+func (l *Loop) collectHealthErrors(ctx, loopCtx context.Context,
+	done chan<- struct{}, healthErrCh <-chan error,
+) {
+	defer close(done)
 	var previousHealthErr error
 	for {
 		select {


### PR DESCRIPTION
# Description

EDIT by qdm12

The healthchecker can panic with `panic: runtime error: integer divide by zero` (stack at `internal/healthcheck/checker.go` in `fullPeriodicCheck`).

It's a race condition where the "previous" healthchecker stops AFTER the healthchecker is re-configured and started, instead of BEFORE.

Fix is relatively simple, although near impossible for LLMs to find, https://github.com/passteque/gluetun/pull/3400/changes/5c7f447c3a8683245de603b9599e509c100a7ae0. It now waits for the previous "collect health error and stop healthchecker" goroutine to exit before attempting to reconfigure the healthchecker in a subsequent VPN run.

I also removed the `configMutex` field in the healthchecker which was never meant to be there, the comment on its method `SetConfig` says `// This function MUST be called before calling [Checker.Start].` highlighting it's not meant to be run at runtime. And the `Stop()` method does stop all sub-goroutines before clearing the config, so there is no need for that mutex, as long as the calling layer (`onTunnelUp`) use it properly in the order `SetConfig -> Start -> Stop`

# Issue

Closes #3398 and #3395

# Assertions

* [x] I am aware that any changes to settings should be reflected in the [wiki](https://github.com/qdm12/gluetun-wiki/) — N/A, this change adds no settings and does not alter existing settings.
